### PR TITLE
chore: clarify public/internal posture split (constitution 1.0.1 + FR-010)

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -2,7 +2,7 @@
 ═══════════════════════════════════════════════════════════════════════════════
 SYNC IMPACT REPORT
 ═══════════════════════════════════════════════════════════════════════════════
-Version Change: Initial → 1.0.0
+Version Change: Initial → 1.0.0 → 1.0.1
 Action: Establish program-level constitution for the rettX patient registry,
         sitting above the per-repo technical constitutions in rettxweb,
         rettxadmin, and rettxapi.
@@ -190,15 +190,26 @@ public.
   reviewer, expected revisit date) — privacy is not a default; it is a
   considered exception.
 
-**Current state**: this control-plane repo and the reusable libraries
-(`rettxmutation`, `rettxid`) are public. The surface and backend
-repositories (`rettxweb`, `rettxadmin`, `rettxapi`) are currently
-private — a deliberate position reflecting the registry's risk posture
-for code that directly handles patient data. This position is intended
-to be revisited as the project matures, in line with this principle.
+**Current state**: this control-plane repo is public. All ecosystem
+repositories (`rettxweb`, `rettxadmin`, `rettxapi`, `rettxmutation`,
+`rettxid`) are currently private — a deliberate position reflecting
+the registry's risk posture for code that directly handles or supports
+patient data. This position is intended to be revisited as the project
+matures, in line with this principle.
+
+**Posture vs. gaps — applied to security and other reviews**:
+public-facing artefacts in this repo and on `docs.rettx.eu` (specs,
+ADRs, aggregate pages such as `architecture/security.md`) describe
+the controls and posture **in place**. Gap analyses, unmitigated risks,
+remediation backlog, scanner findings, and any content that would hand
+an attacker a roadmap stay in the originating private repo (typically
+in that repo's own `SECURITY.md` or an `INTERNAL.md`-style document)
+and are referenced from the public aggregate only as "see private
+repo" placeholders, never inlined.
 
 **Rationale**: The bias toward openness is what makes the project credible.
-Each closed door requires a reason that holds up to scrutiny.
+Each closed door requires a reason that holds up to scrutiny — and
+"would help an attacker" is one such reason that holds up.
 
 ### VIII. Sustainability and stewardship
 
@@ -305,4 +316,14 @@ for stack-specific technical principles within their own scope.
 This constitution evolves with the project. Maintainers SHOULD review it
 at least annually and after any major incident or scope change.
 
-**Version**: 1.0.0 | **Ratified**: 2026-05-01 | **Last Amended**: 2026-05-01
+**Version**: 1.0.1 | **Ratified**: 2026-05-01 | **Last Amended**: 2026-05-01
+
+<!--
+1.0.1 (PATCH): Clarified Principle VII to explicitly cover the
+*content* of public-facing posture artefacts (aggregate security page,
+docs.rettx.eu): controls in place are public; gap analyses and
+improvement backlogs stay in the originating private repo. Also
+updated the "Current state" paragraph to reflect that all ecosystem
+repos are currently private (rettxmutation and rettxid included).
+-->
+

--- a/specs/001-security-deep-dive/spec.md
+++ b/specs/001-security-deep-dive/spec.md
@@ -258,6 +258,17 @@ a docs page. No new infrastructure is invented.
   itself are reviewed during incident response and which during
   routine periodic review, so a maintainer reading it knows which
   parts are "load-bearing" in an incident.
+- **FR-010**: **Public / internal split.** The aggregate page on
+  the public rettx repo (and its rendering on `docs.rettx.eu`) MUST
+  describe **controls in place** only — what the program does to
+  protect the data. Improvement areas, unmitigated risks, scanner
+  findings, threat-model details that hand an attacker a roadmap, and
+  remediation backlog MUST NOT appear there. Each downstream repo is
+  currently private and MAY (and SHOULD) record its own gap analysis
+  in its `SECURITY.md` or an adjacent file; the rettx aggregate
+  references those repos but does not inline the gap content.
+  Constitution Principle VII (Open by default, private only when
+  justified) is the governing rule.
 - **FR-010**: All inapplicable answers MUST carry a one-line
   rationale ("Not applicable — this service handles no
   patient-identifying data") rather than being blank or omitted.


### PR DESCRIPTION
## Why

The security deep-dive review surfaces both `what we do` (controls) and `what we should improve` (gaps). All five downstream repos are private, so they can hold gap analyses freely. **rettx is public** — and its aggregate `architecture/security.md` will be rendered on `docs.rettx.eu`.

Without an explicit rule, a well-meaning squad could inline a `known issues` block straight into the public aggregate. We don't want that.

## What

**Constitution 1.0.0 → 1.0.1 (PATCH)**: Principle VII (`Open by default, private only when justified`) gets a small `Posture vs. gaps` clause that explicitly covers the *content* of public-facing posture artefacts. Also fixes the `Current state` paragraph, which incorrectly listed `rettxmutation` and `rettxid` as public.

**Spec 001 (security-deep-dive)**: New `FR-010 — Public / internal split` makes the rule binding on the in-flight security review. Aggregate page = controls only. Gap analyses live in each (private) downstream repo's own `SECURITY.md`.

## Scope

- `.specify/memory/constitution.md` — Principle VII clarified, Sync Impact Report bumped to 1.0.1, version footer updated, change-note appended.
- `specs/001-security-deep-dive/spec.md` — FR-010 added.

No code, no docs site, no workflow changes. The 5 in-flight downstream issues will get a follow-up comment with the rule once this merges, so any work-in-progress drafts (rettxweb#143 is mid-flight; Squad locally on rettxapi) is corrected before publication.

## Constitution check

- ✅ Principle III (Transparency above all): we still publish posture publicly.
- ✅ Principle VII (Open by default, private only when justified): now spelled out at content-level, not just repo-level.
- ✅ Principle II (Privacy by design): unchanged.

## Out of scope

- No new private repo (option A from the discussion was over-engineering — the existing private repos already are the `private channel`).
- No new GH advisories workflow.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>