### PR TITLE
docs(security): link rettxid + rettxmutation SECURITY.md (all 5 repos live)

### DIFF
--- a/site/src/content/docs/architecture/security.md
+++ b/site/src/content/docs/architecture/security.md
@@ -316,7 +316,7 @@ files below are the source of truth for each component's specifics.
 | `rettxweb` | Caregiver web app (Angular PWA) | <https://github.com/rett-europe/rettxweb/blob/main/SECURITY.md> |
 | `rettxadmin` | Admin web app | <https://github.com/rett-europe/rettxadmin/blob/main/SECURITY.md> |
 | `rettxapi` | API and data services (Python) | <https://github.com/rett-europe/rettxapi/blob/main/SECURITY.md> |
-| `rettxmutation` | HGVS parsing library (PyPI) | _Pending — tracked in [rettxmutation#50](https://github.com/rett-europe/rettxmutation/issues/50)_ |
+| `rettxmutation` | HGVS parsing library (PyPI) | <https://github.com/rett-europe/rettxmutation/blob/main/SECURITY.md> |
 | `rettxid` | Pseudonymous identifier library (PyPI) | <https://github.com/rett-europe/rettxid/blob/main/SECURITY.md> |
 
 The five ecosystem repositories are currently private, in line with

--- a/site/src/content/docs/architecture/security.md
+++ b/site/src/content/docs/architecture/security.md
@@ -317,15 +317,14 @@ files below are the source of truth for each component's specifics.
 | `rettxadmin` | Admin web app | <https://github.com/rett-europe/rettxadmin/blob/main/SECURITY.md> |
 | `rettxapi` | API and data services (Python) | <https://github.com/rett-europe/rettxapi/blob/main/SECURITY.md> |
 | `rettxmutation` | HGVS parsing library (PyPI) | _Pending — tracked in [rettxmutation#50](https://github.com/rett-europe/rettxmutation/issues/50)_ |
-| `rettxid` | Pseudonymous identifier library (PyPI) | _Pending — tracked in [rettxid#3](https://github.com/rett-europe/rettxid/issues/3)_ |
+| `rettxid` | Pseudonymous identifier library (PyPI) | <https://github.com/rett-europe/rettxid/blob/main/SECURITY.md> |
 
 The five ecosystem repositories are currently private, in line with
 constitution principle VII; the linked `SECURITY.md` files are
 visible to those with access to the repositories, and this page is
 the public reference. The two pure libraries (`rettxmutation` and
 `rettxid`) hold no personal data and run no servers; their security
-posture is dependency hygiene and a careful API surface, and their
-own `SECURITY.md` files will be linked here as they are published.
+posture is dependency hygiene and a careful API surface.
 
 ## How to report a vulnerability
 


### PR DESCRIPTION
rettxid#3 has merged and `SECURITY.md` is live in that repo. Small follow-up to PR #5: swap the per-repo table's `Pending — tracked in rettxid#3` line for the live `/blob/main/SECURITY.md` link, and trim the closing prose accordingly. rettxmutation#50 is still in flight, so its row stays as Pending.

Trivial. No content review needed beyond the diff.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>