### PR TITLE
Message Center: relocate spec to control plane + gap-analysis-first pipeline

### DIFF
--- a/.github/workflows/iris-route.yml
+++ b/.github/workflows/iris-route.yml
@@ -13,6 +13,10 @@ name: Iris — route
 #   5. Comments on the parent with the list of created issues, applies
 #      the `routed` label.
 #
+# Scope: single-repo work only. If the parent issue is labelled
+# `cross-cutting`, the workflow refuses and points to the gap-analysis →
+# spec → spec-fanout pipeline (see docs/adr/0002).
+#
 # Idempotency: if the parent already has the `routed` label, the workflow
 # refuses to run again. Re-routing requires manually removing `routed`.
 on:
@@ -62,6 +66,14 @@ jobs:
           if [[ ",$existing," == *",routed,"* ]]; then
             gh issue comment "$ISSUE_NUM" --repo "$ISSUE_REPO" --body \
               "🤖 Iris: this issue is already \`routed\`. Remove the label to re-route."
+            exit 0
+          fi
+
+          # Refuse on cross-cutting issues: those do NOT get a raw fan-out.
+          # They go through gap analysis → umbrella spec → spec-fanout (ADR 0002).
+          if [[ ",$existing," == *",cross-cutting,"* ]]; then
+            gh issue comment "$ISSUE_NUM" --repo "$ISSUE_REPO" --body \
+              "🤖 Iris: this issue is labelled \`cross-cutting\`, so it does **not** get a raw \`/route confirm\` fan-out. It goes through gap analysis → an umbrella spec in [\`specs/\`](https://github.com/${ISSUE_REPO}/tree/main/specs) → \`spec-fanout\` (see [ADR 0002](https://github.com/${ISSUE_REPO}/blob/main/docs/adr/0002-cross-cutting-gap-analysis-pipeline.md)). If this is genuinely single-repo work, remove the \`cross-cutting\` label and comment \`/route confirm\` again."
             exit 0
           fi
 

--- a/.github/workflows/iris-triage.yml
+++ b/.github/workflows/iris-triage.yml
@@ -14,6 +14,9 @@ name: Iris — triage
 #   - Open issues in the downstream repos. That's `iris-route.yml`,
 #     guarded by a `/route confirm` from a repo collaborator. Triage is
 #     a proposal; routing is a human-confirmed action.
+#   - For `cross-cutting` issues it does NOT recommend `/route confirm` at
+#     all: those go through gap analysis → umbrella spec → `spec-fanout`
+#     (see docs/adr/0002). `/route confirm` is for single-repo work only.
 on:
   issues:
     types: [opened, labeled]
@@ -155,7 +158,16 @@ jobs:
             echo
             echo "---"
             echo
-            echo "If this looks right, a repo collaborator can comment **\`/route confirm\`** to fan this issue out as sub-issues in the target repos (each labeled \`squad\`)."
+            if [[ "$cross_cutting" == "true" || "$needs_spec" == "true" ]]; then
+              echo "**Next step — this is cross-cutting, so it does _not_ get a raw \`/route confirm\` fan-out.**"
+              echo "It goes through the gap-analysis → spec pipeline instead (see [ADR 0002](https://github.com/${ISSUE_REPO}/blob/main/docs/adr/0002-cross-cutting-gap-analysis-pipeline.md)):"
+              echo
+              echo "1. A maintainer runs a **gap analysis** from the control plane — one read-only session per affected repo — to ground the work in what each repo already has."
+              echo "2. An **umbrella spec** is authored here under \`specs/NNNN-slug/\`, hosting the shared API contract under \`contracts/\` as the single source of truth."
+              echo "3. On merge, **\`spec-fanout\`** opens one grounded \`[spec/<slug>]\` issue (label \`squad\`) per repo listed in the spec's \`fanout:\` frontmatter."
+            else
+              echo "If this looks right, a repo collaborator can comment **\`/route confirm\`** to fan this single-repo issue out as a sub-issue in the target repo (label \`squad\`)."
+            fi
             echo "To re-run triage, remove and re-add the \`needs-triage\` label."
           } > comment.md
 

--- a/.specify/memory/patterns.md
+++ b/.specify/memory/patterns.md
@@ -153,17 +153,43 @@ form the contract between intake and execution.
 In downstream repos, the `squad` label is the trigger for that repo's
 local Squad/Copilot agent to begin work.
 
+**Cross-cutting issues do not use the raw `/route confirm` fan-out.** The
+`route:*` + `/route confirm` path (`iris-route`) copies the issue text into a
+single downstream repo and is reserved for **single-repo, no-spec** work. When an
+issue is `cross-cutting`, it goes through gap analysis → umbrella spec →
+`spec-fanout` instead (see §7 and [ADR 0002](../../docs/adr/0002-cross-cutting-gap-analysis-pipeline.md)).
+`iris-route` refuses to run on a `cross-cutting` issue.
+
 ## 7. Spec authoring
 
 - Cross-cutting specs live in `rettx/specs/NNNN-slug/` and follow the
-  spec-kit structure: `spec.md`, `plan.md`, `tasks.md`.
-- `tasks.md` MUST group tasks by target repo (front-matter or section per
-  repo) so the fanout action can scope downstream issues correctly.
+  spec-kit structure: `spec.md`, `plan.md`, plus supporting docs
+  (`research.md`, `contracts/`) as needed.
+- **Gap analysis first.** Before authoring a cross-cutting spec, run a
+  gap analysis from the control plane: one **read-only orchestrated session per
+  affected repo**, each reporting file-grounded findings (what exists, what's
+  missing, where new code lands, effort, and any cross-repo conflicts). The
+  umbrella spec is written from those findings, not from the issue text alone.
+  See [ADR 0002](../../docs/adr/0002-cross-cutting-gap-analysis-pipeline.md).
+  - *Precondition*: every target repo must be registered as a **main-checkout**
+    project. Spawning a session against a worktree-backed project fails
+    (`os error 267`).
+- **The umbrella spec hosts the shared API contract** under
+  `specs/NNNN-slug/contracts/`. The control plane owns the contract's location
+  as the single source of truth; `rettxapi` **implements and versions** it.
+  Frontends consume it and never redefine endpoint shapes.
+- **Fan-out is driven by the spec's YAML frontmatter, not `tasks.md`.** The
+  `spec-fanout` workflow reads the `fanout:` array in `spec.md` frontmatter —
+  each entry is `{ repo, summary }` — and opens one `[spec/<slug>]` squad issue
+  per listed repo on merge. Fan-out runs **only** when the spec's `status` is
+  `ready` or `accepted`; a `draft` spec never fans out. Allowed repos:
+  `rettxweb, rettxadmin, rettxapi, rettxmutation, rettxid`.
 - Single-repo work does not require a cross-cutting spec; it can flow
-  directly through the downstream repo's local spec-kit workflow.
+  directly through the downstream repo's local spec-kit workflow (reached via
+  the `/route confirm` path — see §6).
 - The line between "single-repo" and "cross-cutting" is whether the change
-  requires *coordinated* releases or schema changes across repos. When in
-  doubt, treat as cross-cutting.
+  requires *coordinated* releases or schema changes across repos, or hosts a
+  shared contract. When in doubt, treat as cross-cutting.
 
 ## 8. Documentation surfaces
 
@@ -195,3 +221,4 @@ local Squad/Copilot agent to begin work.
 | Date | Change |
 |---|---|
 | 2026-05-01 | Initial version (1.0.0). |
+| 2026-06-22 | §6/§7: cross-cutting work goes via gap-analysis → umbrella spec → `spec-fanout` (frontmatter `fanout:`, not `tasks.md`); `/route confirm` reserved for single-repo work (ADR 0002). |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,9 +56,15 @@ The flow is:
 
 1. Open a **Spec proposal** issue describing the problem and the
    intended outcome.
-2. After triage and a constitution check, run `/speckit.specify` from
-   your editor (or hand-create `specs/<NNNN>-<slug>/spec.md` from the
-   template) on a feature branch.
+2. After triage and a constitution check, run a **gap analysis** across
+   the affected repositories — one read-only session per repo, driven
+   from this control plane (see
+   [ADR 0002](docs/adr/0002-cross-cutting-gap-analysis-pipeline.md)) — to
+   ground the work in what each repo already has. Then run
+   `/speckit.specify` from your editor (or hand-create
+   `specs/<NNNN>-<slug>/spec.md` from the template) on a feature branch,
+   writing it from those findings and hosting any shared API contract
+   under `contracts/`.
 3. The spec is iterated on until it is "Ready". Set the frontmatter
    `status: ready` and fill the `fanout:` block with one entry per
    downstream repo that needs to act, each with a per-repo `summary:`.

--- a/docs/adr/0001-control-plane-repo.md
+++ b/docs/adr/0001-control-plane-repo.md
@@ -62,6 +62,11 @@ releases continue to flow through PyPI and are pinned by `rettxapi`.
 
 ### Spec & issue flow
 
+> **Amended by [ADR 0002](0002-cross-cutting-gap-analysis-pipeline.md)**: the
+> `/route confirm` fan-out below is now reserved for **single-repo** work.
+> Cross-cutting issues go through gap analysis → umbrella spec → `spec-fanout`
+> instead of a raw fan-out.
+
 ```
 issue opened here
         │

--- a/docs/adr/0002-cross-cutting-gap-analysis-pipeline.md
+++ b/docs/adr/0002-cross-cutting-gap-analysis-pipeline.md
@@ -1,0 +1,148 @@
+# ADR 0002 — Gap-analysis-first pipeline for cross-cutting work
+
+- **Status**: Accepted
+- **Date**: 2026-06-22
+- **Decision-makers**: rettX maintainers
+- **Amends**: [ADR 0001](0001-control-plane-repo.md) (the *cross-cutting* portion of
+  its "Spec & issue flow"; single-repo routing is unchanged)
+
+## Context
+
+ADR 0001 established `rettx` as the control plane and defined two flows: a
+`/route confirm` fan-out (Iris copies the raw issue body into sub-issues in the
+target repos) and a `spec-fanout` for cross-cutting specs. In practice the first
+flow was being used for cross-cutting features too — and that exposed two
+structural problems, both observed concretely on
+[rettx#10](https://github.com/rett-europe/rettx/issues/10) ("rettX Message Center"):
+
+1. **Triage is blind to code.** `iris-triage` classifies from the issue *text*
+   only (a GitHub Models call). It has no visibility into the downstream
+   codebases, which live in separate repos. So when `/route confirm` fanned #10
+   out to `rettxweb`, `rettxadmin`, and `rettxapi`, each repo received the same
+   raw brief with no grounding in what already exists there.
+
+2. **The shared boundary landed in a consumer.** Left to execute independently,
+   `rettxapi` authored the full umbrella spec *and both API contracts* inside its
+   own repo. The contract that `rettxweb` and `rettxadmin` must consume ended up
+   hosted in one of the consumers — the opposite of single-source-of-truth — and
+   a genuine **cross-repo conflict** (three different language-code conventions
+   for the same template-rendering call) went undetected because no one was
+   looking at all three repos at once.
+
+The control plane's distinctive value is exactly that holistic view. A blind,
+text-only fan-out throws it away at the very moment it is most needed.
+
+## Decision
+
+For **cross-cutting** issues (more than one repo, or crossing a trust boundary),
+Iris **no longer auto-fans-out the raw issue**. Instead we insert a
+gap-analysis-and-spec step, owned in the control plane, ahead of fan-out:
+
+```
+issue opened here
+        │
+        ▼
+  Iris triage → labels (route:* / cross-cutting / needs-spec) → posts recommendation
+        │
+        ├─ single-repo, no spec needed ─────────────► /route confirm → iris-route
+        │                                             (raw sub-issue in the one repo)
+        │
+        └─ cross-cutting / needs-spec ──────────────► gap analysis (here)
+                                                              │
+                 read-only orchestrated session per repo,    │
+                 reporting file-grounded findings back        ▼
+                                              spec authored here in specs/NNNN-slug/
+                                              (spec.md + plan.md + research.md +
+                                               contracts/ as the single source of truth)
+                                                              │
+                                                       spec PR merges to main
+                                                              │
+                                                              ▼
+                                              spec-fanout reads the `fanout:` frontmatter
+                                              → one grounded [spec/<slug>] squad issue per repo
+```
+
+Concretely:
+
+- **`iris-route` (raw `/route confirm` fan-out) is reserved for single-repo,
+  no-spec work.** It refuses to run on an issue labelled `cross-cutting` and
+  points the maintainer at the spec pipeline instead.
+- **`iris-triage`** still classifies and labels, but its recommendation comment
+  is branched: for cross-cutting / needs-spec issues it recommends the
+  gap-analysis → spec route and does **not** offer `/route confirm`.
+- **Gap analysis** is performed from the control plane via **read-only
+  orchestrated sessions, one per affected repo**, each reporting file-grounded
+  findings (what exists, what's missing, where new code lands, effort, and any
+  cross-repo conflicts). The findings inform the umbrella spec.
+- **The umbrella spec is authored here** and **hosts the shared API contract**
+  under `specs/NNNN-slug/contracts/`. `rettxapi` *implements and versions* the
+  contract; it does not own its location. The spec's machine-read `fanout:`
+  frontmatter carries a per-repo, gap-informed brief.
+- **`spec-fanout`** (unchanged mechanism) opens the grounded squad issues on
+  merge — but only when the spec's `status` is `ready` or `accepted`, so a
+  `draft` umbrella spec never fans out prematurely.
+
+### Prerequisite — target repos must be main-checkout projects
+
+Gap analysis spawns a session per repo. A session created against a
+**worktree-backed** project fails at creation (`os error 267`, "The directory
+name is invalid"). Every repo that needs gap analysis must therefore be
+registered as a normal **main-checkout** project (e.g. `C:\rettx\rettxadmin`)
+before the orchestration runs. This bit us on the first run (`rettxadmin` had to
+be re-registered) and is now a documented precondition.
+
+## Alternatives considered
+
+### A. Keep the raw `/route confirm` fan-out for everything
+
+Rejected. It is fast but produces ungrounded sub-issues and, as #10 showed, lets
+the shared contract and cross-repo conflicts fall through the cracks. It defeats
+the control plane's reason to exist.
+
+### B. Make `iris-triage` read the downstream code directly
+
+Rejected for now. The triage Action would need cross-repo read tokens and a much
+larger model budget, and it still wouldn't match the depth of a per-repo session
+that can run tools and cite files. The orchestrated-session approach keeps triage
+cheap and puts the deep analysis where the code is.
+
+### C. Author the umbrella spec without a gap-analysis step
+
+Rejected. Without first reading each repo, the umbrella spec repeats the original
+mistake — plausible on paper, wrong in detail (e.g. it would not have caught the
+language-code conflict or the absence of durable async infrastructure in
+`rettxapi`).
+
+## Consequences
+
+### Positive
+
+- Cross-cutting fan-out is **grounded**: each squad issue reflects what actually
+  exists in its repo.
+- The shared contract has a single, neutral home in the control plane; consumers
+  stop redefining it.
+- Cross-repo conflicts surface **before** the lanes diverge, when they are cheap
+  to resolve.
+- `draft` umbrella specs cannot fan out by accident.
+
+### Negative
+
+- Cross-cutting work has a heavier front end (gap analysis + spec authoring)
+  before any downstream issue exists.
+- Requires the main-checkout-project precondition to be satisfied for every
+  target repo before orchestration.
+
+### Neutral
+
+- Single-repo issues are unaffected: `/route confirm` → `iris-route` still works
+  exactly as in ADR 0001.
+- The `spec-fanout` workflow itself is unchanged; only *when* we rely on it
+  (after gap analysis, never after a raw fan-out) changes.
+
+## Follow-ups
+
+- Reflected in `patterns.md` §6 (routing labels) and §7 (spec authoring).
+- Resolve the language-code conflict (decision D1) surfaced by the #10 gap
+  analysis as part of `specs/032-message-center/`.
+- Consider a lightweight `needs-spec` label so triage can mark the gap-analysis
+  path explicitly.

--- a/site/src/content/docs/welcome/ecosystem.md
+++ b/site/src/content/docs/welcome/ecosystem.md
@@ -44,11 +44,14 @@ issues in each downstream repository.
 2. The **Iris** automation classifies the issue and labels it with the
    target route (`route:web`, `route:admin`, `route:api`,
    `route:mutation`, `route:id`, or `cross-cutting`).
-3. A maintainer with `write` permission or above confirms the routing
-   with a `/route confirm` comment.
-4. For point fixes, Iris opens a linked issue in the target
-   repository. For cross-cutting changes, a specification is written
-   here first and then fanned out on merge.
+3. **For point fixes** (a single repo), a maintainer with `write`
+   permission or above confirms the routing with a `/route confirm`
+   comment, and Iris opens a linked issue in that repository.
+4. **For cross-cutting changes**, we don't fan the raw issue out. A
+   maintainer first runs a *gap analysis* across the affected
+   repositories, then writes a single specification here — including the
+   shared API contract. When that spec is merged, it is fanned out as a
+   grounded, tracked issue in each affected repository.
 
 See the [contributing guide](https://github.com/rett-europe/rettx/blob/main/CONTRIBUTING.md)
 for the human-facing version of this flow.

--- a/specs/032-message-center/contracts/admin-api-contract.md
+++ b/specs/032-message-center/contracts/admin-api-contract.md
@@ -1,0 +1,94 @@
+# Published API Contract — Admin Messaging
+
+**Feature**: `032-message-center` | **Hosted by**: rettX control plane (this spec) · **Implemented + versioned by**: `rettxapi`
+**Consumer**: `rettxadmin` dashboard (§10)
+**Umbrella**: [rettx#10](https://github.com/rett-europe/rettx/issues/10) · **Contract version**: `v0.1 (draft)`
+
+> **Scope of this document.** This is the **published interface** for admin messaging — the
+> single source of truth all sides agree on, hosted in the control plane and implemented +
+> versioned by `rettxapi`. It defines *only the API the admin dashboard consumes*; the
+> admin-frontend UI is specified by the `rettxadmin` lane (parent issue §10 "Admin frontend
+> impact"). Shapes are indicative until frozen at backend Phases P3–P5 (see [../plan.md](../plan.md));
+> changes require a version bump + a heads-up to the `rettxadmin` lane.
+
+## 1. Endpoints (admin-authenticated, `require_admin`)
+
+Existing endpoints (`POST /send-email`, campaign endpoints from spec `027`) remain live; the new
+create-then-deliver behavior layers underneath and existing admin workflows are preserved until
+the P7 cutover (FR-026).
+
+| Method | Path (indicative) | Purpose |
+|---|---|---|
+| `POST` | `/admin/messages` | Create + deliver an individual message (persist first, email async). |
+| `POST` | `/admin/messages/preview` | Render preview for a template + language + version (no send). |
+| `GET` | `/admin/messages` | List/filter sent messages (caregiver, patient, category, campaign, date, status, template) + pagination. |
+| `GET` | `/admin/messages/{message_id}` | Message detail incl. delivery + read status. |
+| `POST` | `/admin/messages/{message_id}/resend` | Resend failed email delivery (same message). |
+| `POST` | `/admin/communications/bulk` | Create a bulk communication → one message per caregiver (reuses campaign lifecycle). |
+| `GET` | `/admin/communications/{campaign_id}` | Bulk send detail with per-recipient delivery status. |
+| `POST` | `/admin/communications/{campaign_id}/retry` | Idempotent retry of failed recipients. |
+| `GET` | `/admin/communication-templates` | List versioned communication templates (selection/preview). |
+
+> Exact placement (new `admin/messages.py` vs. extending `admin/communications.py` /
+> `admin/campaigns.py`) is finalized at P3–P5 to preserve current admin workflows.
+
+## 2. Shapes (indicative)
+
+**Create individual (request)**:
+```json
+{
+  "recipient_principal_id": "…",
+  "template_id": "survey-invitation",
+  "template_version": "1.2",
+  "language": "pt",
+  "patient_id": "…",
+  "category_code": "survey-invitation",
+  "variables": { "…": "…" },
+  "idempotency_key": "…"
+}
+```
+
+**Message + delivery (response)**:
+```json
+{
+  "id": "…",
+  "reference_id": "MSG-20260622-AB12CD",
+  "recipient_principal_id": "…",
+  "patient_id": null,
+  "category_code": "survey-invitation",
+  "language": "pt",
+  "template": { "id": "survey-invitation", "version": "1.2" },
+  "is_read": false, "read_at": null,
+  "deliveries": [
+    { "channel": "email", "status": "sent", "sent_at": "…", "error": null, "provider_ref": "…" }
+  ],
+  "created_at": "…", "created_by": "admin-user-id"
+}
+```
+
+## 3. Conventions
+
+- Hyphenated codes; full UTC timestamps.
+- Delivery `status` ∈ `pending | sent | failed | not_attempted`.
+- Re-send of a completed campaign → `409 Conflict` (consistent with spec `027`).
+- A **persisted rettX message** is distinct from its **email delivery** — the response models
+  both (message envelope + `deliveries[]`), so the UI can show the distinction (umbrella §10).
+
+## 4. Sequencing
+
+1. Backend P3–P5 build, then **freeze** this contract (`v0.1` → `v1.0`).
+2. `rettxadmin` migrates send + status screens onto the new endpoints (old still live).
+3. Backend P7 routes existing admin email workflows through message creation (cutover).
+
+## 5. Open items needing a joint decision (rettxapi ↔ rettxadmin)
+
+- **O1**: Surface read status for all messages or only selected categories?
+- **O2**: Bulk audience selection model (reuse current patient-cohort selection → resolve caregivers).
+- **O3**: How much of the old "send email" screen is replaced vs. wrapped during P3–P7 transition.
+- **O4**: Umbrella Q3 (send-time status vs. bounce webhooks) — defines what "delivered" means in UI.
+
+## 6. Coordination
+
+Hosted in the control plane (`specs/032-message-center/`) and linked from the `spec-fanout`
+issue opened in `rettxadmin`. It is the single source of truth for the admin messaging API
+surface; the `rettxadmin` lane consumes it rather than redefining it.

--- a/specs/032-message-center/contracts/caregiver-api-contract.md
+++ b/specs/032-message-center/contracts/caregiver-api-contract.md
@@ -1,0 +1,75 @@
+# Published API Contract — Caregiver Messages
+
+**Feature**: `032-message-center` | **Hosted by**: rettX control plane (this spec) · **Implemented + versioned by**: `rettxapi`
+**Consumer**: `rettxweb` caregiver app (§8)
+**Umbrella**: [rettx#10](https://github.com/rett-europe/rettx/issues/10) · **Contract version**: `v0.1 (draft)`
+
+> **Scope of this document.** This is the **published interface** for the caregiver Messages
+> surface — the single source of truth all sides agree on, hosted in the control plane and
+> implemented + versioned by `rettxapi`. It defines *only the API the caregiver app consumes*;
+> the caregiver-frontend UI is specified by the `rettxweb` lane (parent issue §8 "Caregiver
+> frontend impact"). Treat the shapes below as indicative until frozen at backend Phase P1
+> (see [../plan.md](../plan.md)); changes require a version bump + a heads-up to the `rettxweb` lane.
+
+## 1. Endpoints (caregiver-authenticated)
+
+Auth0 caregiver token → principal. Every response is strictly scoped to the authenticated
+caregiver; cross-caregiver access returns 404 (never discloses existence).
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/v2/messages` | Paginated list of the caregiver's messages (filters: `unread`, `category`, `archived`). |
+| `GET` | `/v2/messages/{message_id}` | Message detail (optionally marks read; see Open Item O1). |
+| `GET` | `/v2/messages/unread-count` | Lightweight unread count for a nav badge. |
+| `POST` | `/v2/messages/{message_id}/read` | Mark a message read (idempotent). |
+| `POST` | `/v2/messages/{message_id}/archive` | Archive/hide (record retained). |
+
+## 2. Shapes (indicative)
+
+**List item**:
+```json
+{
+  "id": "…",
+  "reference_id": "MSG-20260622-AB12CD",
+  "category_code": "survey-invitation",
+  "title": "…",
+  "preview": "…",
+  "is_read": false,
+  "read_at": null,
+  "is_archived": false,
+  "patient_ref": { "patient_id": "…", "display_safe": true },
+  "created_at": "2026-06-22T10:00:00Z",
+  "links": [ { "type": "survey", "target": "…" } ]
+}
+```
+`patient_ref` is `null` when the message is not patient-linked.
+
+**Detail**: adds full in-app `body`, resolved `links`, `category_code`, `reference_id`,
+`created_at`. Email/HTML channel internals are **not** exposed to caregivers.
+
+## 3. Conventions
+
+- Timestamps: full UTC ISO-8601.
+- i18n: backend sends **structured codes** (`category_code`, separators are **hyphens** e.g.
+  `survey-invitation`); the frontend maps codes → localized strings. The rendered in-app
+  `title`/`body` come from the message **content snapshot** (already localized at send time).
+- Pagination mirrors existing v2 list endpoints (`page`/`page_size` + `total`).
+
+## 4. Sequencing
+
+1. Backend P0–P2 build, then **freeze** this contract (`v0.1` → `v1.0`).
+2. `rettxweb` builds the Messages section against `v1.0`.
+3. Backend P7 enables the caregiver feature flag → section goes live for enabled principals.
+
+## 5. Open items needing a joint decision (rettxapi ↔ rettxweb)
+
+- **O1**: Mark-read on detail-open vs. explicit action (affects unread accuracy + analytics).
+- **O2**: Are links backend-provided (`links[]`) or frontend-derived from `category_code`?
+- **O3**: Patient-access-loss behavior (umbrella Q2): hide message entirely vs. show generic
+  record without patient specifics — must match the backend decision in [../spec.md](../spec.md).
+
+## 6. Coordination
+
+Hosted in the control plane (`specs/032-message-center/`) and linked from the `spec-fanout`
+issue opened in `rettxweb`. It is the single source of truth for the caregiver API surface; the
+`rettxweb` lane consumes it rather than redefining it.

--- a/specs/032-message-center/plan.md
+++ b/specs/032-message-center/plan.md
@@ -1,0 +1,122 @@
+# Working Plan: rettX Message Center
+
+**Implementation lane**: `rettxapi` (backend) | **Date**: 2026-06-22 | **Spec**: [spec.md](spec.md) | **Gap analysis**: [research.md](research.md)
+**Status**: Skeleton plan for the backend slice (the `go:needs-research` phase). Per-section
+technical detail is filled in the `rettxapi` repo (services/endpoints) with data/security/testing
+review; this copy is the control-plane reference for the API lane.
+
+> Guiding constraint from Pedro: **the live stable version is the basis of everything.** Every
+> phase must be additive and mergeable to `main` with **zero behavioral change** to existing
+> production flows until explicitly turned on. Mirror the `031-rettx-pulse` approach: small,
+> independently mergeable phases, each producing something exercisable in a real environment.
+
+---
+
+## 1. Technical Context
+
+- **Language/Runtime**: Python 3.11, FastAPI ≥0.115, Azure Functions v4 (Python worker).
+- **Data**: Azure Cosmos DB. **New container** `messages` (partition leaning `/recipient_id`
+  for caregiver-scoped reads — finalized in §4). Reuse `bulk_email_campaigns` for bulk fan-out,
+  `audit_events` for the separate comms audit domain.
+- **Templates/Storage**: Azure Blob (existing email-template container) extended to
+  channel-aware, versioned communication templates.
+- **Email channel**: existing `EmailServices` (SendGrid) reused as the channel adapter.
+- **Auth**: Auth0 caregiver tokens (`get_current_user_id`), admin gate (`require_admin`),
+  `PatientAccess` for patient-linked authorization.
+- **Async**: persist-then-deliver-async; all I/O async (Constitution IX).
+- **Testing**: pytest + pytest-asyncio + httpx; three-layer boundary (router mocks service,
+  service mocks repo, repo mocks Cosmos/Blob/SendGrid clients).
+- **Feature flag**: gate caregiver-facing surfaces behind a principal feature flag
+  (pattern: `019-principal-feature-flags`) so production sees no change until enabled.
+
+## 2. Constitution Check (gate)
+
+See spec §"Constitution Check" — all 10 principles addressed. Re-checked at every phase exit.
+Key gates: caregiver/patient authorization tests (III, V); additive endpoints only (VI);
+no PHI in logs/email (II, III); domain exceptions in repo → HTTPException in service (VIII).
+
+## 3. Phased delivery (additive, no production disruption)
+
+Each phase is one reviewable PR, merges to `main`, and is safe in production (new code paths
+unused/flagged until the activating phase).
+
+| Phase | Title | Outcome (exercisable) | Prod impact |
+|---|---|---|---|
+| **P0** | Container + Message model + repository | `messages` container provisioned; `Message` + `Delivery` models; repository CRUD with tests. No endpoints. | None (new container, no traffic) |
+| **P1** | Caregiver read API (MVP) — *US1, US5* | `GET /v2/messages`, `GET /v2/messages/{id}`, `GET /v2/messages/unread-count`, `POST /v2/messages/{id}/read`. Strict self-scoping. Seedable via repo. | None (new endpoints, flagged) |
+| **P2** | Communication templates + rendering + snapshot — *US2 deps, FR-010/011/014* | Versioned comm templates (in-app + email channel reps); render + preview; content snapshot. Existing email templates mapped to email channel. | None (existing email send unchanged) |
+| **P3** | Individual send via create-then-deliver — *US2* | Admin creates a Message → persisted → email delivered async → status tracked. New message visible in P1 API. | None until admin uses new path; old `/send-email` preserved |
+| **P4** | Bulk send fan-out — *US3* | Campaign send creates one Message per resolved caregiver (reusing `027` lifecycle); idempotent retry; per-recipient delivery. | None until used; old bulk path preserved |
+| **P5** | Admin visibility + resend — *US4* | Admin list/filter (caregiver, patient, category, campaign, date, status, template), delivery + read status, resend failed. | None |
+| **P6** | Caregiver archive + comms audit domain — *US6, FR-028/029* | Archive/hide; `MESSAGES` audit domain + `log_message_event`. | None |
+| **P7** | Cutover + flag enablement | Enable caregiver feature flag; route existing admin email workflows through message creation (FR-026); deprecate-in-place old direct-email path. | **Behavioral switch** — done last, after web/admin ready |
+| **P8 (future)** | Provider webhooks / push channel | Optional: bounce webhook (Q3); push as 2nd channel (reuse push infra). | Out of v1 |
+
+**MVP** = P0 + P1 + P2 + P3 (a caregiver sees persisted messages; an admin sends one that
+persists + emails + tracks). P4–P6 complete the operational loop; P7 flips production.
+
+## 4. Open design items to finalize before P0 freeze
+
+- **Partition key**: `/recipient_id` (caregiver-scoped list/unread-count are the hot reads) vs.
+  `/id`. Lean `/recipient_id`; admin cross-caregiver queries use cross-partition queries with
+  filters (acceptable; admin volume low). Confirm with data reviewer.
+- **Reference ID format**: human-safe, email-exposable (e.g. `MSG-{yyyymmdd}-{short}`), unique.
+- **Delivery model**: embedded list on Message vs. separate sub-records. Lean embedded
+  `deliveries[]` for v1 (single email channel, low cardinality) — simpler reads.
+- **Idempotency key** for sends (FR-019): derive from campaign id + recipient id (bulk) and an
+  explicit client idempotency token (individual) to prevent double-submit.
+- **Resolve Q1/Q2/Q3** (retention/GDPR, patient-access loss behavior, webhook scope).
+
+## 5. Cross-team coordination plan (strict)
+
+The API contract is the shared boundary; freeze it per slice before frontends build.
+
+```text
+Backend P0–P2 ─┐
+               ├─(freeze caregiver contract)──► rettxweb builds Messages section (US1/US5/US6 UI)
+Backend P1 ────┘
+Backend P3–P5 ─(freeze admin contract)────────► rettxadmin migrates send screens + status UI
+Backend P7 ────(both frontends ready)─────────► enable flag → production cutover
+```
+
+- **rettxweb** (caregiver app, umbrella §8). Owns: Messages list/detail, unread badge, mark-read,
+  archive, empty/loading states, mobile + a11y, i18n rendering from content snapshot. **Consumes**
+  `contracts/caregiver-api-contract.md` (this slot); the UI gap analysis lives in its derived plan.
+- **rettxadmin** (admin dashboard, umbrella §10). Owns: individual + bulk send UI, preview,
+  language/template version selection, delivery + read status, filtering, resend, reference-ID
+  display, preserving current admin workflows. **Consumes** `contracts/admin-api-contract.md`
+  (this slot); the UI gap analysis lives in its derived plan.
+- **Coordination mechanism**: the two `contracts/*.md` files in this slot are the single source of
+  truth for the API surface; the consuming lanes use them rather than redefining shapes. The
+  `spec-fanout` issues opened in each repo are cross-linked to the parent
+  [rettx#10](https://github.com/rett-europe/rettx/issues/10); changes to a frozen contract require a
+  noted version bump and a heads-up to the consuming lane.
+
+## 6. Testing strategy
+
+- **Repo layer** (P0): CRUD, partition behavior, etag concurrency, domain exceptions.
+- **Service layer** (P1–P6): self-scoping authorization, patient-access enforcement (Q2),
+  render/snapshot reproducibility, persist-before-deliver ordering, idempotent retry.
+- **Router layer**: status codes, pagination, filter correctness, 404/forbidden cross-caregiver.
+- **Mandatory negative tests**: caregiver A cannot read caregiver B's message (SC-007); bulk
+  retry creates no duplicates (SC-004); template edit does not change past snapshot (SC-008).
+- **Regression**: existing `010`/`027` email + campaign tests must stay green through P7.
+
+## 7. Risks & mitigations
+
+- **R1 — Production regression on existing email flows.** Mitigation: P3/P4 add *new* paths;
+  old paths untouched until P7; full regression suite gate.
+- **R2 — Frontend/backend contract drift.** Mitigation: versioned contract docs frozen per
+  slice; companion issues; no silent contract changes.
+- **R3 — PHI leakage in email/logs.** Mitigation: content snapshot keeps clinical detail in-app;
+  email bodies generic; no PHI in logs/spans (II/III); security review at P2/P3.
+- **R4 — Cosmos partition mis-choice hurting caregiver reads.** Mitigation: decide in §4 with
+  data reviewer before P0 freeze; `/recipient_id` favors the hot path.
+- **R5 — GDPR erasure undefined (Q1).** Mitigation: resolve before P0 storage freeze.
+
+## 8. Definition of done (v1)
+
+- SC-001…SC-008 met; MVP (P0–P3) demonstrable end-to-end in a real environment.
+- Existing admin email/campaign workflows preserved and green (FR-026, SC-006).
+- Caregiver/patient authorization proven by tests (SC-007).
+- Contract docs frozen and consumed by `rettxweb` + `rettxadmin`; production flag enabled (P7).

--- a/specs/032-message-center/research.md
+++ b/specs/032-message-center/research.md
@@ -1,0 +1,187 @@
+# Research & Gap Analysis: rettX Message Center
+
+**Feature**: `032-message-center` | **Date**: 2026-06-22 | **Spec**: [spec.md](spec.md)
+**Basis**: live stable `main` @ `0462f9e` (v0.0.44 + #291/#292/#293)
+
+This document captures the gap analysis explicitly requested: **current functionality vs.
+what the Message Center needs**. Status legend: ✅ FULLY present · 🟡 PARTIAL · ❌ ABSENT.
+Each row cites concrete files/symbols so the implementation plan can reuse, not rebuild.
+
+---
+
+## 1. Summary scorecard
+
+| Capability area | Status today | Reuse vs. build |
+|---|---|---|
+| 1. Email sending (SendGrid) | 🟡 individual-send only | Reuse client; wrap behind delivery layer |
+| 2. Email templates (Blob + Jinja2) | 🟡 no versioning, no in-app/channel split | Extend → communication templates |
+| 3. Bulk communication (campaign lifecycle) | ✅ draft→send→track→retry | Reuse as bulk fan-out engine |
+| 4. Caregiver / Principal model | ✅ rich profile, language, email | Reuse as recipient identity |
+| 5. In-app message persistence / inbox | ❌ none (push history ≠ inbox) | **Build** (core of this feature) |
+| 6. Routers (admin + v2 caregiver) | ✅ structure exists | Add message routers |
+| 7. Repository / Cosmos patterns | ✅ singleton + async + partition | Reuse for `messages` container |
+| 8. Audit logging | ✅ domain-based, fire-and-forget | Add `MESSAGES`/comms domain (separate) |
+| 9. Auth / permissions | ✅ token + admin + patient-access | Reuse for caregiver + patient scoping |
+| 10. Delivery status tracking | 🟡 send-time only, no webhooks | Reuse send-time; webhooks deferred |
+
+**Net**: ~70% of the supporting infrastructure already exists. The genuinely new build is the
+**persisted message record + caregiver inbox API** (area 5) and the **template evolution** to
+channel-aware, versioned communication templates (area 2). Everything else is reuse/extension.
+
+---
+
+## 2. Detailed gap analysis
+
+### 2.1 Email sending — 🟡 PARTIAL
+- `app/services/admin/email_services.py` — `EmailServices` singleton, `SendGridAPIClient`,
+  exponential backoff (5 retries), `send_email(to_email, template_name, language, variables)`,
+  fires audit events on success/failure.
+- `app/routers/admin/communications.py` — `POST /send-email` (single send),
+  guarded by `require_admin`, calls `admin_services.send_email_to_user()`.
+- `app/core/config.py` — `RETTX_SENDGRID_API_KEY`, `RETTX_SENDER_EMAIL`,
+  `RETTX_STORAGE_EMAIL_TEMPLATE_CONTAINER`.
+- **Gaps**: no async-decoupled delivery (send is inline); no provider webhooks
+  (bounce/open/click); delivery status = "API accepted", not "delivered".
+- **Decision**: keep `EmailServices` as the email **channel adapter**; the new delivery
+  orchestrator calls it. Persist message first, then deliver async (FR-016).
+
+### 2.2 Email/communication templates — 🟡 PARTIAL
+- `app/services/admin/email_template_loader.py` — `BlobTemplateLoader` loads
+  `{template}/{language}.html` and `.subject.txt` from Blob; Jinja2; not cached.
+- `app/models/admin/email_models.py` — `EmailTemplateEnum` (welcome, reminder_genetics,
+  no_rett_diagnosis, missing_mutation_in_report, missing_patient_info,
+  information_request_custom, missing_name, missing_surname, missing_dob,
+  info_mismatch_name, info_mismatch_dob). Naming aligns with `FileStatus` (spec `010`).
+- `app/models/user/user_preferences.py` — `LANGUAGE_MAP` (supported languages).
+- **Gaps**: ❌ no versioning/rollback, ❌ no in-app vs email channel split (email-only today),
+  ❌ no audit of template changes, ❌ enum-bound (no dynamic templates).
+- **Decision**: introduce **communication templates** carrying channel-specific localized
+  representations (in-app title/body, email subject/HTML/text; reserved push). Version them;
+  message creation snapshots rendered output + template id/version (FR-006, FR-010, FR-011).
+  Backward compatibility: existing email templates map to the email channel of a comm template.
+
+### 2.3 Bulk communication — ✅ FULLY present (foundation)
+- `app/models/admin/campaign_models.py` — `CampaignDocument` (draft/completed, patient_ids,
+  aggregate counts, created_by/at, sent_by/at), `RecipientRecord` (per-patient status, error),
+  max 100 patients/campaign.
+- `app/repository/campaign_repository.py` — `CampaignRepository`, container
+  `bulk_email_campaigns`, partition `/campaign_id`.
+- `app/services/admin/campaign_services.py` — create/send/get/list/retry_failed/delete_draft;
+  resolves principal per patient; loops `email_services.send_email()`; per-recipient status.
+- `app/routers/admin/campaigns.py` — create/update/send/list/detail/retry/delete.
+- **Gap vs. Message Center**: campaigns currently fan out **emails**, not **persisted
+  messages**. The "one document per recipient" requirement (FR-002) maps cleanly: each
+  `RecipientRecord` becomes (or spawns) a persisted Message.
+- **Decision**: reuse the campaign lifecycle as the **bulk fan-out engine**. On send, create
+  one Message per resolved caregiver, then deliver. Idempotency + retry already modeled (FR-019).
+
+### 2.4 Caregiver / Principal model — ✅ FULLY present
+- `app/models/principal/principal_models.py` — `Principal` (BaseDocument): `email`,
+  `email_verified`, `identities[]`, `profile` (given_name, family_name,
+  `preferences.language`, location, contact_info), `status` (PROVISIONAL/ACTIVE/LOCKED).
+- Container `principals_v2`, partition `/id`.
+- **Gap**: `email_verified` may be false → email targeting must handle unverified/missing email
+  gracefully (still persist in-app message). Minor.
+- **Decision**: Principal is the **recipient** identity. Recipient key on Message = principal id.
+
+### 2.5 In-app message persistence / inbox — ❌ ABSENT (the core build)
+- Closest existing concept: `app/models/notification/notification_models.py`
+  `PushNotificationHistory` (id, user_id, title, body, category, is_read, read_at,
+  delivery_status) + `push_notification_repository.py` (container `notifications`,
+  partition `/user_id`) + `notification_history_services.py`.
+- **This is push history, not a message inbox**: it records *push* sends, is admin-oriented,
+  and is not the canonical user-facing record decoupled from a channel.
+- **Decision**: **Build** a dedicated `Message` model + `messages` container + message
+  repository + caregiver-facing service/endpoints. The push-notification history is a useful
+  *pattern reference* (read/unread, pagination, filtering) but not the storage.
+- **Note**: when push is added later, the existing push infra (`push_notification_services.py`,
+  device tokens) becomes a **second delivery channel** for a Message — confirming the
+  channel-agnostic design.
+
+### 2.6 Routers — ✅ FULLY present (structure)
+- Admin: `app/routers/admin/` (communications, campaigns, audit, principals, patient_access, …).
+- Caregiver/user-facing: `app/routers/v2/` (careprofile, files, mutations, patients, pulse,
+  surveys). New caregiver message endpoints belong here (e.g. `app/routers/v2/messages.py`).
+- Guards: `app/dependencies/admin.py` (`require_admin`),
+  `app/dependencies/user_permissions.py` (`get_current_user_id`).
+- **Decision**: add `v2/messages.py` (caregiver) + `admin/messages.py` (admin), or fold admin
+  send into `admin/communications.py`/`admin/campaigns.py` to preserve current workflows.
+
+### 2.7 Repository / Cosmos patterns — ✅ FULLY present
+- `app/models/core/core_models.py` — `BaseDocument` (id, created_at, created_by, version,
+  last_updated_at, last_updated_by, is_deleted).
+- Pattern (e.g. `campaign_repository.py`): singleton `get_instance()` + `asyncio.Lock`,
+  async `_initialize()`, `create_item`/`query_items`/`replace_item` (+ etag),
+  `create_container_if_not_exists`.
+- Config: every container has `RETTX_{NAME}_CONTAINER_NAME` + `RETTX_{NAME}_PARTITION_KEY`.
+- **Decision**: new container `messages` (name/partition finalized in plan.md, leaning
+  partition `/recipient_id` for caregiver-scoped reads). Follow the standard repository pattern.
+
+### 2.8 Audit logging — ✅ FULLY present
+- `app/models/core/audit_event.py` — `AuditEvent` (patient_id, domain, event_type, timestamp,
+  actor_id, correlation_id, outcome, metadata, retention_tier); `AuditDomain` includes **EMAIL**;
+  `RetentionTier` (STANDARD ≥12mo, LONG ≥7yr).
+- `app/services/audit_services.py` — `AuditServices` singleton, fire-and-forget,
+  `log_email_event(...)` and domain helpers.
+- `app/repository/audit_event_repository.py` — append-only, container `audit_events`,
+  partition `/patient_id`.
+- **Decision**: per FR-028, the Message Center is **separate** from audit. Add a communications
+  audit domain (e.g. `MESSAGES` / `COMMUNICATION`) and `log_message_event(...)` helper for
+  lifecycle events (created/delivered/read/resent/archived). Messages are user-facing records;
+  audit stays internal. A message MAY carry an audit correlation id.
+
+### 2.9 Auth / permissions — ✅ FULLY present
+- `app/authentication/auth0_client.py` (`Auth0Client`), `get_current_user_id()`
+  (`user_permissions.py`), admin gate (`admin.py`/`admin_permissions.py`).
+- `app/models/patient_access/patient_access_models.py` — `PatientAccess`
+  (principal_id, patient_id, access_level, consent, revocation; `is_active`).
+- `app/models/core/core_models.py` — `AccessLevelEnum` (NONE/READONLY/EDIT/OWNER).
+- **Decision**: caregiver endpoints scope every query to `get_current_user_id()`'s principal;
+  patient-linked content additionally checks `PatientAccess.is_active`. Resolves Q2.
+
+### 2.10 Delivery status tracking — 🟡 PARTIAL
+- `campaign_models.py` `RecipientRecord.status` (SENT/FAILED) + error; campaign aggregates.
+- `notification_models.py` `DeliveryStatus` (per-device for push).
+- Audit dual-write of send outcome.
+- **Gap**: ❌ no provider webhooks (bounce/open/click); status = send-time only.
+- **Decision**: v1 uses send-time status on the Delivery record (FR-017). Webhook ingestion is
+  an optional future increment (Q3); the Delivery model leaves room for provider references.
+
+---
+
+## 3. Key design decisions (from gaps)
+
+- **D1 — Persist before deliver**: Message is the source of truth; delivery is a side effect
+  (FR-001, FR-016). Reuses async patterns already in the codebase.
+- **D2 — One document per recipient** (FR-002): aligns with `RecipientRecord` granularity;
+  keeps read state, authz, and future personalization simple; partition by recipient.
+- **D3 — Communication templates supersede email templates** (FR-010/011): additive — existing
+  email templates become the email channel of a versioned comm template; content snapshot at
+  send time guarantees reproducibility (D-comply with i18n "structured codes" platform rule).
+- **D4 — Reuse campaign lifecycle for bulk** (FR-019): campaigns fan out to Messages, not raw
+  emails; idempotency/retry already present.
+- **D5 — Audit stays separate** (FR-028): new comms audit domain; Message Center is not the
+  audit log.
+- **D6 — Channel-agnostic delivery**: email is the only v1 channel; push infra already exists and
+  slots in later as a second channel with no message-model change.
+
+---
+
+## 4. Open questions (mirror spec) — to resolve with product/security before plan freeze
+
+- **Q1 — Retention & GDPR erasure** of messages/deliveries (redact-with-tombstone vs. delete).
+- **Q2 — Patient-access loss**: hide vs. redact patient-linked content (lean: hide patient
+  specifics, keep generic record; see D-§2.9).
+- **Q3 — Delivery fidelity for v1**: send-time status only vs. minimum bounce webhook.
+
+## 5. Cross-repo dependencies
+
+This gap analysis backs the backend (`rettxapi`) slice of [rettx#10](https://github.com/rett-europe/rettx/issues/10).
+The control plane owns the published API contract; the two frontends consume the contract and own
+their own UI in their derived plans:
+
+- **rettxweb** (§8): caregiver app consumes the caregiver message endpoints and owns the Messages
+  UI. Published contract: `contracts/caregiver-api-contract.md`.
+- **rettxadmin** (§10): admin dashboard migrates existing send screens to create-then-deliver and
+  owns delivery/read status UI. Published contract: `contracts/admin-api-contract.md`.
+- No changes required to `rettxmutation` or `rettxid`.

--- a/specs/032-message-center/spec.md
+++ b/specs/032-message-center/spec.md
@@ -1,0 +1,536 @@
+<!--
+  Frontmatter below is machine-read by .github/workflows/spec-fanout.yml when
+  this spec is merged into main. The `fanout` array drives which downstream
+  repos get a `[spec/<slug>] <title>` issue with the `squad` label. Set
+  `status: ready` when this spec should fan out on merge — drafts will not.
+
+  Allowed fanout repos: rettxweb, rettxadmin, rettxapi, rettxmutation, rettxid.
+-->
+---
+spec_id: "032"
+slug: "message-center"
+title: "rettX Message Center"
+status: draft   # draft | ready | accepted | superseded
+authored: "2026-06-22"
+author: "perocha"
+source_issue: "rett-europe/rettx#10"
+fanout:
+  - repo: rettxapi
+    summary: |
+      Backend + data model (§9), and OWNER of the implementation of the shared
+      API contract hosted in this spec (`contracts/caregiver-api-contract.md`,
+      `contracts/admin-api-contract.md`). Build a persist-first **Message**
+      (one document per caregiver, optional patient ref, category, read state,
+      stable reference ID, reproducible content snapshot) and a per-channel
+      **Delivery** (email only in v1) with retry/resend. Evolve the blob email
+      templates into **versioned communication templates** (in-app + email +
+      reserved push fields). Add caregiver v2 endpoints (list/detail/unread-
+      count/read/archive) and admin endpoints (send individual + bulk, preview,
+      list/filter, resend) with bulk idempotency. Add a MESSAGE audit domain
+      (distinct from the audit log). New Cosmos container `messages` partitioned
+      by `/recipient_id`. Reuse the existing SendGrid send, bulk-campaign engine,
+      audit service, and PatientAccess authZ (~70% of infra already exists).
+      KEY DECISION (D2): no durable async infrastructure exists today — deliver
+      **synchronously** in v1 (persisted message + `failed` status + admin
+      resend), treating a Storage Queue worker as a funded fast-follow, not an
+      assumption. Implement strictly to the contracts under `contracts/`; do not
+      redefine endpoint shapes.
+  - repo: rettxweb
+    summary: |
+      Caregiver web app (§8) — greenfield Messages surface. Add a `/messages`
+      list + `/messages/:id` detail, a read/unread indicator + mark-as-read, and
+      an app-wide unread-count **badge** (the nav `NavItem.badgeKey` is already
+      reserved) fetched globally after login, all gated behind a program-reserved
+      `messages` feature flag. CONSUME `contracts/caregiver-api-contract.md` — do
+      not invent endpoints. Reuse the existing Auth0 auto-token interceptor and
+      the `care-profile.service` pattern. Add chrome i18n keys across all
+      language files; treat the message **body** as backend-localized opaque
+      content (sanitize if HTML). For patient-linked messages, render only what
+      the backend returns — never infer patient access client-side. Mind the
+      canonical language-code decision (D1).
+  - repo: rettxadmin
+    summary: |
+      Admin dashboard (§10) — evolve the EXISTING individual-send and bulk
+      email-campaign UIs to route through the new persist-first message
+      creation. Surface the message **reference ID** and per-message delivery +
+      read status, clearly distinguishing a persisted rettX message from its
+      email delivery. Add a content **preview** (new) and a language/template-
+      version selector (new); add a filterable **message index** screen; rely on
+      backend idempotency for bulk (keep the existing 100-cap, dedupe, and
+      "recently emailed" safeguards). Preserve current workflows — mind the
+      entangled forkJoin file-validation flow in `genetic-files-section`. CONSUME
+      `contracts/admin-api-contract.md`. Reconcile the language-code naming
+      mismatch (admin i18n uses ISO 3166-1 country codes) per decision D1.
+---
+
+# Feature Specification: rettX Message Center
+
+**Spec ID**: `032-message-center` · **Status**: Draft · **Created**: 2026-06-22
+**Source issue**: [rett-europe/rettx#10](https://github.com/rett-europe/rettx/issues/10) (cross-cutting)
+**Owner**: rettX control plane (this repo) — authored and coordinated here; scoped work is fanned out to the affected repos via the `spec-fanout` workflow on merge.
+**Input**: "Introduce a centralized Message Center that persists caregiver communications inside rettX as the canonical user-facing record, with email as the first delivery channel and the architecture ready for future channels (push, etc.)."
+
+## Overview
+
+rettX already sends operational email to caregivers (onboarding, diagnosis validation,
+survey invitations, data-quality requests) both individually and in bulk
+(see specs `010-email-templates`, `027-bulk-email-campaigns`). Today email is the
+*record* of communication: once sent, the caregiver has no in-app history, delivery is
+coupled to email, and adding a second channel (push) would require parallel orchestration.
+
+The **Message Center** inverts this: a **message** is persisted inside rettX *before*
+delivery, becoming the canonical user-facing communication record. Email becomes one
+**delivery** of that message, not the message itself. Version 1 keeps email as the only
+delivery channel but models it as a channel, so push and other channels can be added later
+without re-architecting.
+
+The umbrella issue [rettx#10](https://github.com/rett-europe/rettx/issues/10) is
+**cross-cutting**. This document is the **single program-level specification** for the feature,
+authored and owned in the rettX control plane. It is not scoped to one surface: it covers the
+caregiver app (§8), the backend API & data model (§9), and the admin dashboard (§10) as one
+coherent design, and it **hosts the shared API contract** (`contracts/`) as the single source of
+truth.
+
+On merge, the `spec-fanout` workflow opens one scoped `[spec/message-center]` issue (label
+`squad`) in each affected repo, carrying that repo's gap-informed brief from the `fanout:`
+frontmatter above:
+
+| Surface | Repo | Parent §scope | Role |
+|---|---|---|---|
+| **Backend API & data model** | `rettxapi` | §9 | Implements + versions the shared contract |
+| **Caregiver web app** | `rettxweb` | §8 | Consumes the caregiver contract |
+| **Admin dashboard** | `rettxadmin` | §10 | Consumes the admin contract |
+
+Each repo derives its own implementation plan/tasks from this spec; none redefine the endpoint
+shapes — the **published API contract** under `contracts/` is the agreed boundary.
+
+The first version is **one-way** (rettX → caregiver). Replies go to a monitored mailbox
+(e.g. `support@rettx.eu`); automatic ingestion of replies is out of scope.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Caregiver reads their messages in-app (Priority: P1)
+
+As an authenticated caregiver, I want a Messages section in rettX that lists every
+communication rettX has sent me — newest first, with a clear read/unread indicator — so I
+have one trustworthy history of what rettX told me, independent of my email inbox.
+
+**Why this priority**: This is the core value proposition and the reason the message must
+be persisted before delivery. Without the caregiver-visible history, the Message Center is
+just a renamed email log. It is independently shippable: once messages exist and a list +
+detail + mark-as-read endpoint exist, the caregiver app delivers value even before any new
+admin tooling.
+
+**Independent Test**: Seed N persisted messages for a caregiver, call the list endpoint,
+open one via the detail endpoint, mark it read, and confirm the unread count drops — all
+scoped strictly to the authenticated caregiver.
+
+**Acceptance Scenarios**:
+
+1. **Given** a caregiver with several persisted messages, **When** they request their message
+   list, **Then** they receive their messages in reverse-chronological order with read/unread
+   state, category code, optional patient reference, and a content snapshot, paginated.
+2. **Given** a caregiver opens an unread message, **When** they fetch its detail, **Then** the
+   full in-app title and body are returned and the message becomes read (read timestamp set).
+3. **Given** a caregiver has 3 unread messages, **When** they request their unread count,
+   **Then** the system returns `3`; after reading one it returns `2`.
+4. **Given** caregiver A and caregiver B, **When** caregiver A requests message `M` that
+   belongs to caregiver B, **Then** the system returns 404/forbidden and never discloses B's
+   content or existence.
+5. **Given** a message is linked to a patient, **When** a caregiver who no longer has access
+   to that patient lists messages, **Then** the patient-linked message is not exposed (or is
+   shown without patient-specific content) per the authorization rule.
+6. **Given** a caregiver with no messages, **When** they request their list, **Then** an empty
+   result with total `0` is returned (clean empty state).
+
+---
+
+### User Story 2 — Admin sends an individual message to a caregiver (Priority: P1)
+
+As an admin, I want to send a templated communication to a single caregiver (optionally
+about a specific patient) so that the caregiver gets both a persisted in-app message and an
+email notification, and I can later see whether it was delivered and read.
+
+**Why this priority**: Individual sends are the most common operational action today
+(`POST /send-email`) and must route through the new create-then-deliver flow without losing
+existing capability. It is the smallest end-to-end vertical slice that exercises persist →
+render → deliver → track.
+
+**Independent Test**: As admin, create a message for one caregiver from a template; confirm
+a message document is persisted, an email delivery is attempted and its status recorded, and
+the same message appears in that caregiver's list (Story 1).
+
+**Acceptance Scenarios**:
+
+1. **Given** an admin selects a caregiver, a communication template, and (optionally) a
+   patient, **When** they create the message, **Then** the message is persisted first with a
+   rendered content snapshot and a human-readable **message reference ID**, and only then is
+   email delivery triggered.
+2. **Given** a created message, **When** email delivery succeeds, **Then** the message's email
+   delivery status becomes `sent` with a timestamp; the caregiver can see the message in-app.
+3. **Given** a created message, **When** email delivery fails, **Then** the message remains
+   persisted and visible in-app, the email delivery status becomes `failed` with an error,
+   and the admin can retry delivery without re-creating the message.
+4. **Given** a caregiver whose preferred language is `pt`, **When** the message is rendered,
+   **Then** the in-app and email content use the `pt` representation, falling back to the
+   default language when a translation is missing.
+5. **Given** a message references a patient, **When** it is created, **Then** the admin must
+   hold permission to that patient (and the target caregiver must have access), otherwise the
+   request is rejected.
+
+---
+
+### User Story 3 — Admin sends a bulk communication (one message per caregiver) (Priority: P2)
+
+As an admin, I want to send a communication to a selected population of caregivers so that
+each caregiver receives their **own independent** persisted message and email, with
+per-recipient delivery tracking and no duplicate sends on retry.
+
+**Why this priority**: Bulk is high-value but builds on the individual send slice and the
+existing campaign lifecycle (`027`). Modeling each recipient as an independent message (not
+one shared message with many recipients) keeps read state, permissions, and future
+personalization simple.
+
+**Independent Test**: Create a bulk communication targeting a known cohort; confirm exactly
+one message document per resolved caregiver, independent per-recipient delivery status, and
+that re-triggering does not create duplicates or re-send already-sent recipients.
+
+**Acceptance Scenarios**:
+
+1. **Given** an admin defines a bulk communication over a resolved caregiver cohort, **When**
+   it is sent, **Then** exactly one persisted message is created per caregiver, each with its
+   own reference ID, read state, and delivery record.
+2. **Given** a bulk send where some email deliveries fail, **When** it completes, **Then**
+   aggregate counts and the list of failed recipients with error reasons are reported, and
+   each failed recipient's message is still persisted and visible in-app.
+3. **Given** a bulk send is retried after partial failure, **When** the retry runs, **Then**
+   only previously-failed deliveries are re-attempted (idempotent); already-sent recipients
+   are not re-created or re-emailed.
+4. **Given** a caregiver appears twice in the resolved cohort, **When** the bulk send runs,
+   **Then** de-duplication ensures the caregiver receives a single message for that send.
+
+---
+
+### User Story 4 — Admin observes delivery and read status (Priority: P2)
+
+As an admin, I want to see, for any sent message or bulk communication, the delivery status
+of the email channel and (where appropriate) whether the caregiver has read the in-app
+message, filterable by caregiver, patient, category, campaign, date, template, and status,
+so I can audit communications and follow up on failures.
+
+**Why this priority**: Visibility and resend close the operational loop, but depend on
+messages and deliveries already existing.
+
+**Independent Test**: With a mix of sent/failed/read messages, query the admin listing with
+each filter and confirm correct results, including distinguishing a persisted rettX message
+from its email delivery.
+
+**Acceptance Scenarios**:
+
+1. **Given** sent messages with varied states, **When** an admin lists messages filtered by
+   `status=failed`, **Then** only messages whose email delivery failed are returned.
+2. **Given** a message that the caregiver has opened, **When** an admin views it, **Then** the
+   read indicator and read timestamp are shown.
+3. **Given** a failed email delivery, **When** the admin triggers a resend, **Then** a new
+   delivery attempt is recorded against the same message without creating a new message.
+4. **Given** the admin filters by `campaign`, `category`, `patient`, `template`, and a date
+   range, **When** results are returned, **Then** they honor every supplied filter.
+
+---
+
+### User Story 5 — Caregiver sees a notification badge / unread count after login (Priority: P3)
+
+As a caregiver, I want the app navigation to surface how many unread messages I have, so I
+know to check the Message Center without opening every screen.
+
+**Why this priority**: A nice-to-have that increases engagement; the underlying unread-count
+endpoint (Story 1) is the dependency, so this is mostly a frontend concern.
+
+**Independent Test**: Verify the unread-count endpoint returns an accurate, fast count for a
+caregiver and updates after reads.
+
+**Acceptance Scenarios**:
+
+1. **Given** a caregiver logs in, **When** the app requests the unread count, **Then** a single
+   lightweight call returns the count without fetching full message bodies.
+2. **Given** the caregiver reads all messages, **When** the count is re-requested, **Then** it
+   returns `0`.
+
+---
+
+### User Story 6 — Caregiver archives/hides a message (Priority: P3)
+
+As a caregiver, I want to archive (hide) a message I no longer need in my main list, so my
+Message Center stays tidy — without permanently destroying the communication record.
+
+**Why this priority**: Improves UX but is not required for MVP; archiving must not violate
+traceability (the record is retained, only the caregiver's view changes).
+
+**Independent Test**: Archive a message and confirm it is excluded from the default list,
+still retrievable via an archived filter, and still present for audit/retention.
+
+**Acceptance Scenarios**:
+
+1. **Given** a caregiver archives a message, **When** they request their default list, **Then**
+   the archived message is excluded but the record is retained.
+2. **Given** an archived message, **When** the caregiver requests archived items, **Then** it is
+   returned. Hard deletion of the communication record by caregivers is not permitted.
+
+---
+
+### Edge Cases
+
+- **Template translation missing**: rendering falls back to the configured default language;
+  the chosen language is recorded in the content snapshot.
+- **Template changes after send**: the message retains its rendered snapshot; later template
+  edits never alter what was already communicated.
+- **Caregiver has no verified email**: the in-app message is still persisted; email delivery
+  is skipped or marked `not_attempted`/`failed` with a clear reason, and the caregiver still
+  sees the message in-app.
+- **Caregiver loses patient access after a patient-linked message was sent**: patient-specific
+  content is not disclosed in the in-app history per the authorization rule.
+- **Partial bulk failure mid-run**: each recipient's message and delivery are tracked
+  independently; the operation reports per-recipient outcomes and supports idempotent retry.
+- **Duplicate/double-submit of a send**: idempotency prevents creating duplicate messages or
+  duplicate email deliveries for the same logical send.
+- **Very large cohort**: bulk sends respect a cohort size limit (aligned with existing campaign
+  limits) and persist-then-deliver asynchronously so the request does not block on delivery.
+- **Concurrent read + admin view**: read-state updates are last-write-wins and never block.
+- **Reply received by mailbox**: the email carries the message reference ID so a human can
+  manually correlate a reply to the original message; no automatic ingestion.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements — Message model & persistence
+
+- **FR-001**: The system MUST persist a **message** as a discrete record *before* any delivery
+  is attempted, and MUST treat the persisted message as the canonical user-facing record.
+- **FR-002**: Each message MUST belong to exactly one **recipient caregiver** (one document per
+  caregiver) and MUST NOT be modeled as a single shared message with many recipients.
+- **FR-003**: A message MAY optionally reference exactly one **patient**; patient reference is
+  not required.
+- **FR-004**: Each message MUST carry a stable **message reference ID** that is safe to expose
+  in emails and admin tooling for manual correlation of replies.
+- **FR-005**: Each message MUST record a **category** from a stable, controlled vocabulary
+  (see FR-024) to support filtering, analytics, and future notification preferences.
+- **FR-006**: Each message MUST store a **content snapshot** (the rendered in-app and
+  channel content, plus the language and template version used) so the communicated content is
+  reproducible even after templates change.
+- **FR-007**: Each message MUST track **read/unread state** with a read timestamp, scoped to
+  the recipient caregiver.
+- **FR-008**: The system MUST support caregiver **archive/hide** of a message without
+  destroying the underlying record; caregivers MUST NOT be able to hard-delete records.
+- **FR-009**: The system MUST record creation/update audit fields (who, when) consistent with
+  the platform's base document model.
+
+### Functional Requirements — Templates & rendering
+
+- **FR-010**: The system MUST evolve email templates into **communication templates** that can
+  hold channel-specific representations: in-app title, in-app body, email subject, email HTML
+  body, email plain-text body (and reserved fields for future push title/body).
+- **FR-011**: Communication templates MUST be **versioned**, and message creation MUST capture
+  the template version (or a sufficient content snapshot) that was used.
+- **FR-012**: Rendering MUST honor the recipient's **preferred language** and MUST fall back to
+  the configured default language when a translation is missing, recording the language used.
+- **FR-013**: In-app and email representations of the same message MAY differ; the email SHOULD
+  be able to encourage logging into rettX while the in-app message carries fuller context.
+- **FR-014**: The system MUST allow **previewing** rendered content (per language/version) for
+  a given template before a message is created/sent.
+
+### Functional Requirements — Delivery & channels
+
+- **FR-015**: The system MUST model **delivery** as a per-channel attempt attached to a message;
+  v1 MUST support the **email** channel only while keeping the model channel-agnostic.
+- **FR-016**: The system MUST persist the message first and then trigger delivery
+  **asynchronously**, so the create/send request does not block on the email provider.
+- **FR-017**: Each email delivery MUST record a status (e.g. `pending`, `sent`, `failed`,
+  `not_attempted`) with timestamps and, on failure, an error reason.
+- **FR-018**: The system MUST support **retry/resend** of a failed email delivery against the
+  existing message without creating a new message.
+- **FR-019**: Bulk sends MUST be **idempotent**: retrying MUST NOT duplicate messages or re-send
+  already-delivered recipients, and duplicate recipients in a cohort MUST be de-duplicated.
+- **FR-020**: Email notifications MUST include the message **reference ID** and a clear **reply
+  policy** (e.g. reply-to support mailbox / open rettX for details).
+- **FR-021**: The system SHOULD be able to incorporate provider delivery signals (e.g. bounce)
+  if/when available, but provider webhook ingestion is NOT required for v1 (send-time status is
+  acceptable for v1). *(See Open Question Q3.)*
+
+### Functional Requirements — Caregiver-facing API
+
+- **FR-022**: Caregivers MUST be able to list **only their own** messages, paginated, newest
+  first, with read state, category, optional patient reference, and content snapshot summary.
+- **FR-023**: Caregivers MUST be able to fetch a single message's detail, retrieve an unread
+  count, mark a message read, and archive a message — all strictly scoped to themselves.
+
+### Functional Requirements — Categories, admin, audit, security
+
+- **FR-024**: The system MUST define an initial, stable set of **message categories**:
+  onboarding, diagnosis-validation, file-upload-request, missing-information-request,
+  survey-invitation, consent-update, profile-update-request, research-invitation,
+  system-announcement, support-operational.
+- **FR-025**: Admins MUST be able to create an individual message, create a bulk communication,
+  preview content, list/filter sent messages (by caregiver, patient, category, campaign, date,
+  status, template), view delivery + read status, and resend failed deliveries.
+- **FR-026**: Existing individual and bulk **email workflows MUST be preserved** for admins,
+  routed through the new message-creation process (no loss of current capability).
+- **FR-027**: The system MUST enforce **caregiver-level authorization** so a caregiver can only
+  access their own messages, and **patient-level authorization** so patient-linked content is
+  only exposed to users permitted to that patient.
+- **FR-028**: The Message Center MUST remain **separate from the audit log**: messages store
+  user-facing communications; audit events store internal system/admin events. A message MAY be
+  linked to an audit event but the two MUST remain distinct concepts.
+- **FR-029**: The system MUST emit audit events for message lifecycle (created, delivered,
+  read, resent, archived) under a communications audit domain, without storing PHI unnecessarily.
+- **FR-030**: Email bodies (and future push payloads) MUST avoid unnecessary clinical detail;
+  sensitive context SHOULD live behind authentication in the in-app message. A future push, when
+  added, MUST be generic (e.g. "You have a new message in rettX").
+- **FR-031**: The system MUST define **retention** expectations for messages and deliveries and
+  honor **GDPR** data-subject handling (export/erasure) for caregiver communications.
+  *(See Open Question Q1.)*
+
+### Key Entities *(include if feature involves data)*
+
+- **Message**: A persisted communication for exactly one caregiver. Key attributes: identifier,
+  reference ID, recipient caregiver reference, optional patient reference, category code,
+  language used, content snapshot (in-app title/body + channel content + template id/version),
+  read state + read timestamp, archived state, audit fields, optional campaign/correlation link.
+- **Delivery**: A per-channel send attempt attached to a message. Key attributes: channel
+  (email for v1), status, timestamps, error reason, provider reference. Multiple deliveries
+  (e.g. retries) MAY exist per message per channel.
+- **Communication Template**: A versioned, reusable template holding channel-specific,
+  localized representations (in-app title/body, email subject/HTML/plain text; reserved push
+  fields). Evolves from today's blob-based email templates.
+- **Message Category**: A controlled vocabulary value classifying a message for filtering,
+  analytics, and future notification preferences.
+- **Bulk Communication / Campaign**: The admin-initiated definition of a send over a resolved
+  caregiver cohort that fans out into one Message per recipient (builds on existing campaign
+  lifecycle).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of caregiver communications created through the Message Center are persisted
+  before delivery, and remain visible in-app even when email delivery fails.
+- **SC-002**: A caregiver can find the in-app history of every Message-Center communication
+  rettX sent them, with accurate read/unread state, in one place.
+- **SC-003**: For any sent message, an admin can determine email delivery status and (where
+  applicable) read status, and resend a failed delivery without creating a duplicate message.
+- **SC-004**: Bulk sends produce exactly one message per resolved caregiver with zero duplicate
+  messages or duplicate emails across retries.
+- **SC-005**: The unread-count call for a logged-in caregiver returns quickly enough to drive a
+  navigation badge without fetching message bodies (target: well under typical page-load budget).
+- **SC-006**: No existing admin email workflow regresses; every send that worked before works
+  after, now also producing a persisted message.
+- **SC-007**: No caregiver can ever retrieve another caregiver's message or patient-linked
+  content they are not authorized to see (validated by authorization tests).
+- **SC-008**: The content a caregiver saw at send time is reproducible from the stored snapshot
+  even after the underlying template is edited.
+
+## Cross-Team Coordination *(mandatory for this feature)*
+
+This feature cannot ship from any single repo. It is coordinated from the control plane: this
+spec is the shared design, and the **published API contract** under `contracts/` — **owned here,
+implemented and versioned by `rettxapi`** — is the boundary the two frontends consume rather
+than redefine.
+
+- `contracts/caregiver-api-contract.md` — the caregiver-facing message API (list, detail,
+  unread count, mark-read, archive, content snapshot for i18n). **Consumed by** `rettxweb` (§8).
+- `contracts/admin-api-contract.md` — the admin messaging API (send individual + bulk, preview,
+  language/template-version selection, delivery + read status, filtering, resend, reference-ID).
+  **Consumed by** `rettxadmin` (§10).
+
+**Anti-divergence mechanism**: there is exactly one canonical API contract (these two files in
+the control plane). Frontends do not invent endpoint shapes; changes are versioned here, and the
+`spec-fanout` issues link every repo back to this spec.
+
+**Sequencing principle**: `rettxapi` ships the persist + caregiver-read slice (Story 1 + 2)
+behind no behavioral change to existing flows, then **freezes** the contract; `rettxweb` builds
+the caregiver Messages section against the frozen caregiver contract; `rettxadmin` migrates
+existing send screens onto the new create-then-deliver endpoints while preserving current UX.
+
+### Program-level cross-cutting decisions (from the control-plane gap analysis)
+
+Surfaced by reading all three repos together; each must be decided **once, here**, before the
+lanes diverge:
+
+- **D1 — Canonical language codes.** `rettxweb` resolves caregiver language from Auth0
+  `preferences.language`; `rettxadmin` i18n files use **ISO 3166-1 country codes** (e.g. `se`,
+  `dk`, `cz`); `rettxapi` renders templates by `{language}`. The three MUST agree on one
+  canonical code set + mapping for the language passed to the renderer. *(Open — decision needed.)*
+- **D2 — Synchronous delivery in v1.** `rettxapi` has no durable async infrastructure (no
+  queue / Service Bus / Durable Functions). v1 delivers **synchronously** within the request,
+  with durability via the persisted message + `failed` delivery status + admin resend; a Storage
+  Queue worker is a funded fast-follow, not assumed. Frontends MUST NOT assume queued/async
+  delivery semantics. *(Refines FR-016 and Q3.)*
+- **D3 — Bulk model.** Each caregiver gets one independent persisted message; the existing
+  `rettxapi` campaign engine and `rettxadmin` campaign UI are reused as the fan-out mechanism
+  (one message per recipient), not replaced.
+- **D4 — Feature flag.** A program-reserved `messages` feature flag (surfaced in the caregiver
+  profile `app_metadata.features`) gates staged rollout of the caregiver surface.
+
+## Assumptions
+
+- The existing **Principal** model is the caregiver identity; its `preferences.language`,
+  `given_name`, and email drive rendering and targeting (reused, not rebuilt).
+- The existing **PatientAccess** model governs patient-level authorization for patient-linked
+  messages.
+- The existing **campaign lifecycle** (`027`) and **email send/templating** (`010`) are the
+  foundation; the Message Center wraps and extends them rather than replacing them.
+- Delivery is **asynchronous** (persist first, then deliver); send-time delivery status is
+  acceptable for v1 (provider webhooks optional/future).
+- A new Cosmos container is acceptable for messages; partition strategy favors per-caregiver
+  read performance (finalized in `plan.md`).
+- Email remains the **only** delivery channel in v1; the model is channel-agnostic for future
+  push without re-architecting.
+- Frontend translation of structured codes continues per the platform i18n pattern; the backend
+  provides content snapshots and codes, not localized UI strings beyond rendered message content.
+
+## Out of Scope (v1)
+
+- Push notifications and other non-email channels (model is ready; no delivery in v1).
+- Full bidirectional in-app messaging; caregiver-to-admin chat; message threading.
+- Automatic ingestion of email replies into rettX.
+- Support ticket assignment, SLA, moderation workflows.
+- Structured caregiver request actions from the app (e.g. "contact us about this message",
+  "report incorrect data") — considered for a later version.
+- Provider open/click tracking and webhook-based bounce/complaint handling (optional/future).
+
+## Constitution Check
+
+*GATE: must hold before implementation planning is accepted. Checked against the **program
+constitution** (`.specify/memory/constitution.md`); repo-specific technical principles
+(layering, async-first, API versioning, configuration, error handling) are verified in each
+repo's own derived plan and its local constitution.*
+
+- **I. Patients & caregivers come first (NON-NEGOTIABLE)** — gives caregivers one trustworthy,
+  in-app history of every communication, independent of their email inbox; messages persist and
+  remain visible even when email delivery fails. ✅
+- **II. Privacy by design (NON-NEGOTIABLE)** — caregiver-only + patient-level authorization
+  (FR-027); clinical detail kept out of email/push with sensitive context behind authentication
+  (FR-030); messages kept distinct from the audit log (FR-028); GDPR retention/erasure addressed
+  (FR-031, Q1). ✅
+- **III. Transparency above all (NON-NEGOTIABLE)** — a reproducible content snapshot records
+  exactly what was communicated, even after templates change (FR-006); message lifecycle is
+  audited (FR-029); a stable reference ID supports traceability of replies (FR-004). ✅
+- **IV. Clinical accuracy & accountability** — versioned communication templates; the rendered
+  snapshot is the accountable record of what each caregiver was told (FR-006, FR-011). ✅
+- **V. Accessibility & inclusion** — the caregiver Messages surface follows the web app's
+  WCAG/ARIA and mobile conventions and ships with the full supported-language set for chrome;
+  message bodies are backend-localized (the canonical code set is decision D1). ✅
+- **VI. Security baseline** — authN required on every surface; least-privilege caregiver/patient
+  scoping; no PHI in logs; secrets via Key Vault. ✅
+- **VII. Open by default / VIII. Sustainability & stewardship** — reuses existing SendGrid,
+  campaign, audit and patient-access machinery rather than standing up new infrastructure; the
+  channel-agnostic model avoids re-architecting when push is added later. ✅
+
+## Open Questions *(max 3 — resolve during research)*
+
+- **Q1 [NEEDS CLARIFICATION]**: Retention policy for messages/deliveries and the GDPR
+  export/erasure behavior — does erasure redact content while retaining an audit-safe tombstone,
+  or remove the message entirely? (Drives FR-031 and storage design.)
+- **Q2 [NEEDS CLARIFICATION]**: For patient-linked messages, when a caregiver later loses
+  patient access, should the message be fully hidden or shown with patient-specific content
+  redacted? (Drives FR-027 and US1 scenario 5.)
+- **Q3 [NEEDS CLARIFICATION]**: Is send-time email status sufficient for v1, or is at least
+  bounce handling (provider webhook) required before launch? (Drives FR-021 scope.)


### PR DESCRIPTION
## Why

Issue #10 ("rettX Message Center") was fanned out to the downstream repos by a raw `/route confirm`, and `rettxapi` then authored the full umbrella spec **and both shared API contracts inside its own repo**. That put the shared boundary in a *consumer*, and a real cross-repo conflict (three different language-code conventions for the same template renderer) went undetected because nothing was looking at all three repos at once.

This PR **re-inverts** the flow: the umbrella spec + shared contract live in the control plane, grounded in a gap analysis run across the affected repos — and the pipeline is updated so this happens by default for cross-cutting work.

## What's in here

**1. Spec relocated — `specs/032-message-center/`**
- Program-level umbrella `spec.md` with control-plane framing and machine-read `fanout:` frontmatter carrying a gap-informed brief per repo (`rettxapi` / `rettxweb` / `rettxadmin`). `status: draft` — it will **not** fan out until flipped to `ready`.
- Cross-Team Coordination rewritten to control-plane ownership; the **D1–D4** cross-cutting decisions recorded (language codes, synchronous-delivery-in-v1, bulk model, feature flag).
- Constitution check rewritten against the **program** constitution (non-negotiables I/II/III + IV–VIII).
- Both `contracts/*.md` reframed: hosted here, **implemented + versioned by `rettxapi`**, consumed by the frontends. All stale `squad:` / `#297` / `#165` / `#46` references removed.

**2. Process codified**
- **ADR 0002** — gap-analysis-first pipeline for cross-cutting work (amends ADR 0001).
- **`iris-route`** refuses to raw-fan-out a `cross-cutting` issue; **`iris-triage`** steers cross-cutting / needs-spec issues to the gap-analysis → spec route instead of `/route confirm`. `/route confirm` is now single-repo only.
- **`patterns.md`** — fixes the stale claim that `tasks.md` drives fan-out (it's the spec frontmatter `fanout:` block); documents gap-analysis-first and the main-checkout-project precondition; change-log entry.
- **CONTRIBUTING.md** + docs site (`ecosystem.md`) updated to match.

## Notes
- The companion downstream artifacts opened by the original fan-out (rettxapi#298 PR, sub-issues rettxweb#165 / rettxadmin#46 / rettxapi#297) were already closed with superseding comments, and #10's labels reset to `triaged, cross-cutting`.
- `spec.md` is intentionally `draft`; flip to `ready` to trigger `spec-fanout` on merge.

Refs rett-europe/rettx#10