### PR TITLE
spec(032): version Message Center contracts (v0.2 deltas + freeze caregiver v1.0)

### DIFF
--- a/specs/032-message-center/contracts/admin-api-contract.md
+++ b/specs/032-message-center/contracts/admin-api-contract.md
@@ -2,7 +2,7 @@
 
 **Feature**: `032-message-center` | **Hosted by**: rettX control plane (this spec) · **Implemented + versioned by**: `rettxapi`
 **Consumer**: `rettxadmin` dashboard (§10)
-**Umbrella**: [rettx#10](https://github.com/rett-europe/rettx/issues/10) · **Contract version**: `v0.1 (draft)`
+**Umbrella**: [rettx#10](https://github.com/rett-europe/rettx/issues/10) · **Contract version**: `v0.2 (draft)`
 
 > **Scope of this document.** This is the **published interface** for admin messaging — the
 > single source of truth all sides agree on, hosted in the control plane and implemented +
@@ -19,7 +19,7 @@ the P7 cutover (FR-026).
 
 | Method | Path (indicative) | Purpose |
 |---|---|---|
-| `POST` | `/admin/messages` | Create + deliver an individual message (persist first, email async). |
+| `POST` | `/admin/messages` | Create + deliver an individual message (persist first, deliver synchronously within the request — v1, per D2). |
 | `POST` | `/admin/messages/preview` | Render preview for a template + language + version (no send). |
 | `GET` | `/admin/messages` | List/filter sent messages (caregiver, patient, category, campaign, date, status, template) + pagination. |
 | `GET` | `/admin/messages/{message_id}` | Message detail incl. delivery + read status. |
@@ -40,13 +40,16 @@ the P7 cutover (FR-026).
   "recipient_principal_id": "…",
   "template_id": "survey-invitation",
   "template_version": "1.2",
-  "language": "pt",
   "patient_id": "…",
   "category_code": "survey-invitation",
   "variables": { "…": "…" },
   "idempotency_key": "…"
 }
 ```
+> **`language` is server-derived (D1), not a request field.** The send language is resolved by
+> `rettxapi` from the **recipient caregiver's profile language** (English fallback); admins do not
+> pass it per-send. An optional `language_override` MAY be added later for explicit admin override,
+> but is out of scope for v1.
 
 **Message + delivery (response)**:
 ```json
@@ -69,7 +72,13 @@ the P7 cutover (FR-026).
 ## 3. Conventions
 
 - Hyphenated codes; full UTC timestamps.
-- Delivery `status` ∈ `pending | sent | failed | not_attempted`.
+- `reference_id` format is **`MSG-{yyyymmdd}-{short}`** (e.g. `MSG-20260622-AB12CD`) — shared with
+  the caregiver contract; email-safe, stable, unique.
+- `deliveries[]` is **embedded on the message** (v1 is single-channel email); it is not a separate
+  resource. The model stays channel-agnostic for a future push channel.
+- Delivery `status` ∈ `pending | sent | failed | not_attempted`, recorded from the provider send
+  response at send time (v1, per D2 / umbrella Q3); `provider_ref` is retained for later
+  correlation. No bounce/delivery webhook in v1.
 - Re-send of a completed campaign → `409 Conflict` (consistent with spec `027`).
 - A **persisted rettX message** is distinct from its **email delivery** — the response models
   both (message envelope + `deliveries[]`), so the UI can show the distinction (umbrella §10).
@@ -85,7 +94,9 @@ the P7 cutover (FR-026).
 - **O1**: Surface read status for all messages or only selected categories?
 - **O2**: Bulk audience selection model (reuse current patient-cohort selection → resolve caregivers).
 - **O3**: How much of the old "send email" screen is replaced vs. wrapped during P3–P7 transition.
-- **O4**: Umbrella Q3 (send-time status vs. bounce webhooks) — defines what "delivered" means in UI.
+- **O4 (RESOLVED → send-time status only for v1; umbrella Q3).** "Delivered" in the UI means the
+  provider accepted the send (`sent`); bounce/complaint webhooks are out of scope for v1. The UI
+  shows `pending | sent | failed | not_attempted` and offers resend on `failed`.
 
 ## 6. Coordination
 

--- a/specs/032-message-center/contracts/caregiver-api-contract.md
+++ b/specs/032-message-center/contracts/caregiver-api-contract.md
@@ -2,7 +2,7 @@
 
 **Feature**: `032-message-center` | **Hosted by**: rettX control plane (this spec) · **Implemented + versioned by**: `rettxapi`
 **Consumer**: `rettxweb` caregiver app (§8)
-**Umbrella**: [rettx#10](https://github.com/rett-europe/rettx/issues/10) · **Contract version**: `v0.1 (draft)`
+**Umbrella**: [rettx#10](https://github.com/rett-europe/rettx/issues/10) · **Contract version**: `v0.2 (draft)`
 
 > **Scope of this document.** This is the **published interface** for the caregiver Messages
 > surface — the single source of truth all sides agree on, hosted in the control plane and
@@ -19,7 +19,7 @@ caregiver; cross-caregiver access returns 404 (never discloses existence).
 | Method | Path | Purpose |
 |---|---|---|
 | `GET` | `/v2/messages` | Paginated list of the caregiver's messages (filters: `unread`, `category`, `archived`). |
-| `GET` | `/v2/messages/{message_id}` | Message detail (optionally marks read; see Open Item O1). |
+| `GET` | `/v2/messages/{message_id}` | Message detail. Does **not** mark the message read (read is an explicit action — see O1). |
 | `GET` | `/v2/messages/unread-count` | Lightweight unread count for a nav badge. |
 | `POST` | `/v2/messages/{message_id}/read` | Mark a message read (idempotent). |
 | `POST` | `/v2/messages/{message_id}/archive` | Archive/hide (record retained). |
@@ -50,6 +50,12 @@ caregiver; cross-caregiver access returns 404 (never discloses existence).
 ## 3. Conventions
 
 - Timestamps: full UTC ISO-8601.
+- `reference_id` format is **`MSG-{yyyymmdd}-{short}`** (e.g. `MSG-20260622-AB12CD`): email-safe,
+  stable, and unique — used for reply correlation and support.
+- **Patient-access loss (umbrella Q2, resolved):** when the caregiver no longer has access to a
+  linked patient, the message is **retained and still listed**, but `patient_ref` is returned as
+  `null` and patient-specific content is omitted from `title`/`body`/`preview`. The frontend
+  renders exactly what the backend returns (it does not hide the message itself).
 - i18n: backend sends **structured codes** (`category_code`, separators are **hyphens** e.g.
   `survey-invitation`); the frontend maps codes → localized strings. The rendered in-app
   `title`/`body` come from the message **content snapshot** (already localized at send time).
@@ -63,10 +69,14 @@ caregiver; cross-caregiver access returns 404 (never discloses existence).
 
 ## 5. Open items needing a joint decision (rettxapi ↔ rettxweb)
 
-- **O1**: Mark-read on detail-open vs. explicit action (affects unread accuracy + analytics).
+- **O1 (RESOLVED → explicit read action).** `POST /{message_id}/read` is the **canonical** way to
+  mark a message read; `GET /{message_id}` is read-only and does **not** auto-mark-read. This keeps
+  reads idempotent and unread analytics clean. The frontend marks read on an explicit user action.
 - **O2**: Are links backend-provided (`links[]`) or frontend-derived from `category_code`?
-- **O3**: Patient-access-loss behavior (umbrella Q2): hide message entirely vs. show generic
-  record without patient specifics — must match the backend decision in [../spec.md](../spec.md).
+- **O3 (RESOLVED → redact, do not hide; umbrella Q2).** On patient-access loss the backend keeps
+  the message in the list and returns it with `patient_ref: null` and patient-specifics omitted
+  (see §3). The frontend MUST NOT independently hide patient-linked messages — it renders what the
+  backend returns.
 
 ## 6. Coordination
 

--- a/specs/032-message-center/contracts/caregiver-api-contract.md
+++ b/specs/032-message-center/contracts/caregiver-api-contract.md
@@ -2,14 +2,15 @@
 
 **Feature**: `032-message-center` | **Hosted by**: rettX control plane (this spec) · **Implemented + versioned by**: `rettxapi`
 **Consumer**: `rettxweb` caregiver app (§8)
-**Umbrella**: [rettx#10](https://github.com/rett-europe/rettx/issues/10) · **Contract version**: `v0.2 (draft)`
+**Umbrella**: [rettx#10](https://github.com/rett-europe/rettx/issues/10) · **Contract version**: `v1.0 (FROZEN — caregiver surface; rettxapi P1 shipped 2026-06-22)`
 
 > **Scope of this document.** This is the **published interface** for the caregiver Messages
 > surface — the single source of truth all sides agree on, hosted in the control plane and
 > implemented + versioned by `rettxapi`. It defines *only the API the caregiver app consumes*;
 > the caregiver-frontend UI is specified by the `rettxweb` lane (parent issue §8 "Caregiver
-> frontend impact"). Treat the shapes below as indicative until frozen at backend Phase P1
-> (see [../plan.md](../plan.md)); changes require a version bump + a heads-up to the `rettxweb` lane.
+> frontend impact"). The shapes below are **frozen at v1.0** (backend P1 shipped and verified);
+> `rettxweb` may build against them. Any change now requires a **version bump** (v1.1+) and a
+> heads-up to the `rettxweb` lane.
 
 ## 1. Endpoints (caregiver-authenticated)
 
@@ -21,10 +22,15 @@ caregiver; cross-caregiver access returns 404 (never discloses existence).
 | `GET` | `/v2/messages` | Paginated list of the caregiver's messages (filters: `unread`, `category`, `archived`). |
 | `GET` | `/v2/messages/{message_id}` | Message detail. Does **not** mark the message read (read is an explicit action — see O1). |
 | `GET` | `/v2/messages/unread-count` | Lightweight unread count for a nav badge. |
-| `POST` | `/v2/messages/{message_id}/read` | Mark a message read (idempotent). |
+| `POST` | `/v2/messages/{message_id}/read` | Mark a message read (idempotent). Returns **`204 No Content`**. |
 | `POST` | `/v2/messages/{message_id}/archive` | Archive/hide (record retained). |
 
-## 2. Shapes (indicative)
+## 2. Shapes (frozen at v1.0)
+
+**List response envelope** (`GET /v2/messages`):
+```json
+{ "messages": [ /* list item */ ], "total": 0, "page": 1, "page_size": 20 }
+```
 
 **List item**:
 ```json
@@ -42,10 +48,16 @@ caregiver; cross-caregiver access returns 404 (never discloses existence).
   "links": [ { "type": "survey", "target": "…" } ]
 }
 ```
-`patient_ref` is `null` when the message is not patient-linked.
+`patient_ref` is `null` when the message is not patient-linked (or when patient access is lost —
+see §3). `links` is present but MAY be empty (see O2).
 
-**Detail**: adds full in-app `body`, resolved `links`, `category_code`, `reference_id`,
-`created_at`. Email/HTML channel internals are **not** exposed to caregivers.
+**Detail** (`GET /v2/messages/{message_id}`): adds full in-app `body`, resolved `links`, and drops
+`preview`; otherwise the same fields. Email/HTML channel internals are **not** exposed to caregivers.
+
+**Unread count** (`GET /v2/messages/unread-count`): `{ "unread_count": 0 }`.
+
+**Mark read** (`POST /v2/messages/{message_id}/read`): **`204 No Content`**, empty body; idempotent
+(repeating on an already-read message is a no-op `204`).
 
 ## 3. Conventions
 
@@ -59,12 +71,12 @@ caregiver; cross-caregiver access returns 404 (never discloses existence).
 - i18n: backend sends **structured codes** (`category_code`, separators are **hyphens** e.g.
   `survey-invitation`); the frontend maps codes → localized strings. The rendered in-app
   `title`/`body` come from the message **content snapshot** (already localized at send time).
-- Pagination mirrors existing v2 list endpoints (`page`/`page_size` + `total`).
+- Pagination envelope: `{ messages[], total, page, page_size }` (mirrors existing v2 list endpoints).
 
 ## 4. Sequencing
 
-1. Backend P0–P2 build, then **freeze** this contract (`v0.1` → `v1.0`).
-2. `rettxweb` builds the Messages section against `v1.0`.
+1. ✅ Backend P1 shipped → this contract is **frozen at `v1.0`** (2026-06-22).
+2. `rettxweb` builds the Messages section against `v1.0` (safe to start now).
 3. Backend P7 enables the caregiver feature flag → section goes live for enabled principals.
 
 ## 5. Open items needing a joint decision (rettxapi ↔ rettxweb)
@@ -72,7 +84,11 @@ caregiver; cross-caregiver access returns 404 (never discloses existence).
 - **O1 (RESOLVED → explicit read action).** `POST /{message_id}/read` is the **canonical** way to
   mark a message read; `GET /{message_id}` is read-only and does **not** auto-mark-read. This keeps
   reads idempotent and unread analytics clean. The frontend marks read on an explicit user action.
-- **O2**: Are links backend-provided (`links[]`) or frontend-derived from `category_code`?
+- **O2 (RESOLVED → backend-resolved `links[]`; shape frozen).** Action links are provided by the
+  **backend** as `links[]`, each item `{ "type": "<action-type>", "target": "<url-or-ref>" }`. The
+  frontend renders them as-is and does **not** derive targets from `category_code` (it cannot know
+  the specific survey/file/entity). In P1 the array is present but **empty**; populating it
+  per-message is an **additive** change (not a v1.0 break). The `{ type, target }` shape is frozen.
 - **O3 (RESOLVED → redact, do not hide; umbrella Q2).** On patient-access loss the backend keeps
   the message in the list and returns it with `patient_ref: null` and patient-specifics omitted
   (see §3). The frontend MUST NOT independently hide patient-linked messages — it renders what the

--- a/specs/032-message-center/spec.md
+++ b/specs/032-message-center/spec.md
@@ -298,7 +298,9 @@ still retrievable via an archived filter, and still present for audit/retention.
 - **Duplicate/double-submit of a send**: idempotency prevents creating duplicate messages or
   duplicate email deliveries for the same logical send.
 - **Very large cohort**: bulk sends respect a cohort size limit (aligned with existing campaign
-  limits) and persist-then-deliver asynchronously so the request does not block on delivery.
+  limits) and persist each recipient's message before delivering synchronously within the
+  request (no durable async infrastructure in v1, per D2); the persisted messages are the
+  durable record even if individual deliveries fail.
 - **Concurrent read + admin view**: read-state updates are last-write-wins and never block.
 - **Reply received by mailbox**: the email carries the message reference ID so a human can
   manually correlate a reply to the original message; no automatic ingestion.
@@ -345,8 +347,11 @@ still retrievable via an archived filter, and still present for audit/retention.
 
 - **FR-015**: The system MUST model **delivery** as a per-channel attempt attached to a message;
   v1 MUST support the **email** channel only while keeping the model channel-agnostic.
-- **FR-016**: The system MUST persist the message first and then trigger delivery
-  **asynchronously**, so the create/send request does not block on the email provider.
+- **FR-016**: The system MUST persist the message first and then deliver it **synchronously
+  within the create/send request** in v1 (no durable async infrastructure exists — see D2), so
+  the persisted message is the durable record even if the provider send fails. A durable async
+  worker MAY replace the synchronous path in a later phase without changing the persisted-first
+  guarantee.
 - **FR-017**: Each email delivery MUST record a status (e.g. `pending`, `sent`, `failed`,
   `not_attempted`) with timestamps and, on failure, an error reason.
 - **FR-018**: The system MUST support **retry/resend** of a failed email delivery against the
@@ -357,7 +362,7 @@ still retrievable via an archived filter, and still present for audit/retention.
   policy** (e.g. reply-to support mailbox / open rettX for details).
 - **FR-021**: The system SHOULD be able to incorporate provider delivery signals (e.g. bounce)
   if/when available, but provider webhook ingestion is NOT required for v1 (send-time status is
-  acceptable for v1). *(See Open Question Q3.)*
+  acceptable for v1). *(Resolved — send-time status only for v1; see Q3.)*
 
 ### Functional Requirements — Caregiver-facing API
 
@@ -390,7 +395,7 @@ still retrievable via an archived filter, and still present for audit/retention.
   added, MUST be generic (e.g. "You have a new message in rettX").
 - **FR-031**: The system MUST define **retention** expectations for messages and deliveries and
   honor **GDPR** data-subject handling (export/erasure) for caregiver communications.
-  *(See Open Question Q1.)*
+  *(Resolved — erasure redacts content but keeps an audit-safe tombstone; see Q1.)*
 
 ### Key Entities *(include if feature involves data)*
 
@@ -486,8 +491,8 @@ not diverge:
   messages.
 - The existing **campaign lifecycle** (`027`) and **email send/templating** (`010`) are the
   foundation; the Message Center wraps and extends them rather than replacing them.
-- Delivery is **asynchronous** (persist first, then deliver); send-time delivery status is
-  acceptable for v1 (provider webhooks optional/future).
+- Delivery is **persist-first, then synchronous within the request** in v1 (per D2); send-time
+  delivery status is acceptable for v1 (provider webhooks optional/future).
 - A new Cosmos container is acceptable for messages; partition strategy favors per-caregiver
   read performance (finalized in `plan.md`).
 - Email remains the **only** delivery channel in v1; the model is channel-agnostic for future
@@ -517,8 +522,8 @@ repo's own derived plan and its local constitution.*
   remain visible even when email delivery fails. ✅
 - **II. Privacy by design (NON-NEGOTIABLE)** — caregiver-only + patient-level authorization
   (FR-027); clinical detail kept out of email/push with sensitive context behind authentication
-  (FR-030); messages kept distinct from the audit log (FR-028); GDPR retention/erasure addressed
-  (FR-031, Q1). ✅
+  (FR-030);   messages kept distinct from the audit log (FR-028); GDPR retention/erasure resolved as
+  redact-content-with-audit-safe-tombstone (FR-031, Q1). ✅
 - **III. Transparency above all (NON-NEGOTIABLE)** — a reproducible content snapshot records
   exactly what was communicated, even after templates change (FR-006); message lifecycle is
   audited (FR-029); a stable reference ID supports traceability of replies (FR-004). ✅
@@ -533,13 +538,21 @@ repo's own derived plan and its local constitution.*
   campaign, audit and patient-access machinery rather than standing up new infrastructure; the
   channel-agnostic model avoids re-architecting when push is added later. ✅
 
-## Open Questions *(max 3 — resolve during research)*
+## Resolved Decisions *(Q1–Q3, resolved via provider planning on `rettxapi` #299)*
 
-- **Q1 [NEEDS CLARIFICATION]**: Retention policy for messages/deliveries and the GDPR
-  export/erasure behavior — does erasure redact content while retaining an audit-safe tombstone,
-  or remove the message entirely? (Drives FR-031 and storage design.)
-- **Q2 [NEEDS CLARIFICATION]**: For patient-linked messages, when a caregiver later loses
-  patient access, should the message be fully hidden or shown with patient-specific content
-  redacted? (Drives FR-027 and US1 scenario 5.)
-- **Q3 [NEEDS CLARIFICATION]**: Is send-time email status sufficient for v1, or is at least
-  bounce handling (provider webhook) required before launch? (Drives FR-021 scope.)
+- **Q1 — Retention / GDPR erasure (RESOLVED → redact content + audit-safe tombstone).** Erasure
+  blanks the content snapshot and patient specifics and sets a redaction flag, but **retains the
+  message envelope** (id, reference ID, category code, timestamps, delivery status) so the proof
+  that a communication occurred survives for traceability (Constitution III/IV) and reference-ID
+  reply correlation. Content follows the STANDARD retention tier (≥12 months); the tombstone
+  follows the audit LONG tier. Hard-delete is **not** used. *(Resolves FR-031.)*
+- **Q2 — Patient-access-loss (RESOLVED → redact patient specifics at read time, keep the
+  message).** When a caregiver later loses access to a linked patient, the message is **retained**
+  and its envelope stays visible, but `patient_ref` and patient-specific content are **withheld at
+  read time**; the content snapshot is preserved at rest. The message is **not** hidden entirely.
+  Both API contracts state this so the frontends render only what the backend returns. *(Resolves
+  FR-027 and US1 scenario 5.)*
+- **Q3 — Delivery fidelity (RESOLVED → send-time status only for v1).** Delivery status is recorded
+  from the provider (SendGrid) send response (`sent` / `failed` / `not_attempted`) and
+  `provider_ref` is retained for later correlation; provider bounce/delivery **webhook ingestion
+  is deferred** to a post-v1 phase. *(Resolves FR-021; consistent with D2.)*


### PR DESCRIPTION
## What

Two stacked changes to the published Message Center contracts, driven by the `rettxapi` #299 provider lane:

1. **v0.2 deltas** — resolve Q1–Q3 and the D1/D2 contract impacts.
2. **Freeze caregiver contract → v1.0** — `rettxapi` shipped P1 (the caregiver `/v2/messages` read API) matching v0.2; the three pre-freeze items are confirmed and the response shapes are pinned.

## Resolved decisions (Q1–Q3)

| | Decision |
|---|---|
| **Q1 — GDPR erasure** | Redact content + keep an **audit-safe tombstone**; no hard-delete. |
| **Q2 — Patient-access loss** | **Redact patient specifics at read time, keep the message.** |
| **Q3 — Delivery fidelity** | **Send-time status only** for v1; webhook deferred. |

## Caregiver contract v1.0 (frozen) — pinned shapes

- `POST /{id}/read` → **`204 No Content`** (idempotent).
- List envelope `{ messages[], total, page, page_size }`; unread-count `{ unread_count }`; `patient_ref { patient_id, display_safe }`.
- **O1** explicit read (GET does not auto-mark) · **O2 RESOLVED** → `links[]` are backend-resolved, `{ type, target }` shape frozen (empty in P1; populating later is additive) · **O3** redact-not-hide.

## Admin contract (still `v0.2 draft`)

- `language` is **server-derived (D1)**, not a per-send request field · **O4** send-time status defines "delivered". Freezes at backend **P3**.

## Prose / pins

- FR-016 + Assumptions **async → synchronous** (D2); spec "Open Questions" → "Resolved Decisions"; `reference_id = MSG-{yyyymmdd}-{short}`; `deliveries[]` embedded.

## Fan-out

`status` stays `ready`; the `[spec/message-center]` issues already exist in all three repos, so `spec-fanout` is **idempotent** on merge. `rettxweb` #167 can build against the frozen caregiver v1.0.