### PR TITLE
spec(032): partial-freeze admin contract — individual-send v1.0 (rettxapi P3)

### DIFF
--- a/specs/032-message-center/contracts/admin-api-contract.md
+++ b/specs/032-message-center/contracts/admin-api-contract.md
@@ -2,14 +2,17 @@
 
 **Feature**: `032-message-center` | **Hosted by**: rettX control plane (this spec) · **Implemented + versioned by**: `rettxapi`
 **Consumer**: `rettxadmin` dashboard (§10)
-**Umbrella**: [rettx#10](https://github.com/rett-europe/rettx/issues/10) · **Contract version**: `v0.2 (draft)`
+**Umbrella**: [rettx#10](https://github.com/rett-europe/rettx/issues/10) · **Contract version**: `v0.3 — individual-send surface FROZEN (rettxapi P3 shipped 2026-06-22); bulk + list/filter INDICATIVE pending P4/P5`
 
 > **Scope of this document.** This is the **published interface** for admin messaging — the
 > single source of truth all sides agree on, hosted in the control plane and implemented +
 > versioned by `rettxapi`. It defines *only the API the admin dashboard consumes*; the
 > admin-frontend UI is specified by the `rettxadmin` lane (parent issue §10 "Admin frontend
-> impact"). Shapes are indicative until frozen at backend Phases P3–P5 (see [../plan.md](../plan.md));
-> changes require a version bump + a heads-up to the `rettxadmin` lane.
+> impact"). **Partial freeze:** the **individual-send** endpoints (create / preview / detail /
+> resend) are **frozen at v1.0** (backend P3 shipped + verified) — `rettxadmin` may build against
+> them now. The **bulk** (`/admin/communications/*`) and **list/filter** (`GET /admin/messages`)
+> endpoints remain **indicative** until they freeze at backend **P4 / P5**. Changes to frozen
+> shapes require a version bump (v1.1+) + a heads-up to the `rettxadmin` lane.
 
 ## 1. Endpoints (admin-authenticated, `require_admin`)
 
@@ -17,22 +20,22 @@ Existing endpoints (`POST /send-email`, campaign endpoints from spec `027`) rema
 create-then-deliver behavior layers underneath and existing admin workflows are preserved until
 the P7 cutover (FR-026).
 
-| Method | Path (indicative) | Purpose |
-|---|---|---|
-| `POST` | `/admin/messages` | Create + deliver an individual message (persist first, deliver synchronously within the request — v1, per D2). |
-| `POST` | `/admin/messages/preview` | Render preview for a template + language + version (no send). |
-| `GET` | `/admin/messages` | List/filter sent messages (caregiver, patient, category, campaign, date, status, template) + pagination. |
-| `GET` | `/admin/messages/{message_id}` | Message detail incl. delivery + read status. |
-| `POST` | `/admin/messages/{message_id}/resend` | Resend failed email delivery (same message). |
-| `POST` | `/admin/communications/bulk` | Create a bulk communication → one message per caregiver (reuses campaign lifecycle). |
-| `GET` | `/admin/communications/{campaign_id}` | Bulk send detail with per-recipient delivery status. |
-| `POST` | `/admin/communications/{campaign_id}/retry` | Idempotent retry of failed recipients. |
-| `GET` | `/admin/communication-templates` | List versioned communication templates (selection/preview). |
+| Method | Path | Purpose | Freeze status |
+|---|---|---|---|
+| `POST` | `/admin/messages` | Create + deliver an individual message (persist first, deliver synchronously within the request — v1, per D2). Returns **`201 Created`**. | **FROZEN v1.0** (P3) |
+| `POST` | `/admin/messages/preview` | Render preview for a template + version + recipient-derived language (no send). | **FROZEN v1.0** (P3) |
+| `GET` | `/admin/messages/{message_id}` | Message detail incl. delivery + read status. | **FROZEN v1.0** (P3) |
+| `POST` | `/admin/messages/{message_id}/resend` | Resend a failed delivery by re-delivering the **stored content snapshot** (no re-render, SC-008); appends a new `Delivery`. | **FROZEN v1.0** (P3) |
+| `GET` | `/admin/messages` | List/filter sent messages (caregiver, patient, category, campaign, date, status, template) + pagination. | indicative (P5) |
+| `POST` | `/admin/communications/bulk` | Create a bulk communication → one message per caregiver (reuses campaign lifecycle). | indicative (P4) |
+| `GET` | `/admin/communications/{campaign_id}` | Bulk send detail with per-recipient delivery status. | indicative (P4) |
+| `POST` | `/admin/communications/{campaign_id}/retry` | Idempotent retry of failed recipients. | indicative (P4) |
+| `GET` | `/admin/communication-templates` | List versioned communication templates (selection/preview). | indicative |
 
 > Exact placement (new `admin/messages.py` vs. extending `admin/communications.py` /
 > `admin/campaigns.py`) is finalized at P3–P5 to preserve current admin workflows.
 
-## 2. Shapes (indicative)
+## 2. Shapes — individual send (frozen at v1.0)
 
 **Create individual (request)**:
 ```json
@@ -82,11 +85,18 @@ the P7 cutover (FR-026).
 - Re-send of a completed campaign → `409 Conflict` (consistent with spec `027`).
 - A **persisted rettX message** is distinct from its **email delivery** — the response models
   both (message envelope + `deliveries[]`), so the UI can show the distinction (umbrella §10).
+- **Create** (`POST /admin/messages`) returns **`201 Created`** with the message envelope.
+  **Idempotency (FR-019):** repeating a request with the same `idempotency_key` returns the
+  **existing** message and does **not** create a duplicate or re-send.
+- **Resend** (`POST /admin/messages/{id}/resend`) re-delivers the **stored content snapshot**
+  (no re-render — SC-008) and appends a new `Delivery` entry rather than mutating the prior one.
 
 ## 4. Sequencing
 
-1. Backend P3–P5 build, then **freeze** this contract (`v0.1` → `v1.0`).
-2. `rettxadmin` migrates send + status screens onto the new endpoints (old still live).
+1. ✅ Backend P3 shipped → **individual-send** endpoints (create / preview / detail / resend) are
+   **frozen at `v1.0`** (2026-06-22). `rettxadmin` may migrate the individual-send + status screens
+   now (old `/send-email` still live).
+2. Backend P4 (bulk) and P5 (list/filter) ship → their endpoints freeze to `v1.0` then.
 3. Backend P7 routes existing admin email workflows through message creation (cutover).
 
 ## 5. Open items needing a joint decision (rettxapi ↔ rettxadmin)


### PR DESCRIPTION
## What

`rettxapi` shipped **P3** (admin individual message send) matching the published admin contract **v0.2 shapes 1:1** — no contract deviations. This **partially freezes** the admin contract: the individual-send subset goes to **v1.0**; bulk + list/filter stay indicative until P4/P5.

## Frozen at v1.0 (P3 delivered + verified)

| Endpoint | Pinned detail |
|---|---|
| `POST /admin/messages` | **201 Created**; persist-first, **synchronous** deliver (D2); send-time status only (Q3); **no `language`** in request (server-derived from recipient profile, D1). |
| `POST /admin/messages/preview` | render only, recipient-derived language. |
| `GET /admin/messages/{id}` | detail incl. delivery + read status; does **not** auto-mark-read. |
| `POST /admin/messages/{id}/resend` | re-delivers the **stored snapshot** (no re-render, SC-008); appends a new `Delivery`. |

**Idempotency (FR-019):** a repeat `idempotency_key` returns the **existing** message — no duplicate persist/send.

## Still indicative (freeze at P4/P5)

- `/admin/communications/*` (bulk) → **P4**
- `GET /admin/messages` (list/filter) → **P5**

## Notes

- Contract version → `v0.3` (individual-send FROZEN; rest indicative). Existing `/send-email` + campaign flows untouched (FR-026).
- `rettxadmin` #47 can now build the **individual-send + status** screens against the frozen subset.
- Caregiver contract remains **v1.0 frozen** (merged in #13).