### PR TITLE
spec(032): pin bulk retry response body (additive)

### DIFF
--- a/specs/032-message-center/contracts/admin-api-contract.md
+++ b/specs/032-message-center/contracts/admin-api-contract.md
@@ -140,6 +140,28 @@ counters as create, plus `read_count`):
 }
 ```
 
+**Bulk retry (response, `200`)** — `POST /admin/communications/{campaign_id}/retry`; re-delivers only
+previously-failed recipients (never creates new messages, SC-004). `409` if nothing failed:
+```json
+{
+  "campaign_id": "comm_ab12cd34",
+  "retried": 2,
+  "now_sent": 2,
+  "still_failed": 0,
+  "recipients": [
+    {
+      "recipient_principal_id": "…",
+      "message_id": "…",
+      "reference_id": "MSG-20260623-AB12CD",
+      "delivery_status": "sent",
+      "is_read": false,
+      "error": null
+    }
+  ]
+}
+```
+
+
 ## 2.5 Shapes — list/filter (frozen at v1.0, P5)
 
 **List/filter (request)** — `GET /admin/messages`, all query params optional:


### PR DESCRIPTION
Pins the as-built bulk retry 200 response body { campaign_id, retried, now_sent, still_failed, recipients[] }. The frozen bulk subset (PR #15) pinned retry status (200/409) but not the body. Additive only; create + rollup already match the live backend. Part of #10.