### PR TITLE
spec(032): reconcile audit domain naming to MESSAGE (message)

### DIFF
--- a/specs/032-message-center/plan.md
+++ b/specs/032-message-center/plan.md
@@ -17,7 +17,7 @@ review; this copy is the control-plane reference for the API lane.
 - **Language/Runtime**: Python 3.11, FastAPI ≥0.115, Azure Functions v4 (Python worker).
 - **Data**: Azure Cosmos DB. **New container** `messages` (partition leaning `/recipient_id`
   for caregiver-scoped reads — finalized in §4). Reuse `bulk_email_campaigns` for bulk fan-out,
-  `audit_events` for the separate comms audit domain.
+  `audit_events` for the separate MESSAGE audit domain (`message`).
 - **Templates/Storage**: Azure Blob (existing email-template container) extended to
   channel-aware, versioned communication templates.
 - **Email channel**: existing `EmailServices` (SendGrid) reused as the channel adapter.
@@ -48,7 +48,7 @@ unused/flagged until the activating phase).
 | **P3** | Individual send via create-then-deliver — *US2* | Admin creates a Message → persisted → email delivered async → status tracked. New message visible in P1 API. | None until admin uses new path; old `/send-email` preserved |
 | **P4** | Bulk send fan-out — *US3* | Campaign send creates one Message per resolved caregiver (reusing `027` lifecycle); idempotent retry; per-recipient delivery. | None until used; old bulk path preserved |
 | **P5** | Admin visibility + resend — *US4* | Admin list/filter (caregiver, patient, category, campaign, date, status, template), delivery + read status, resend failed. | None |
-| **P6** | Caregiver archive + comms audit domain — *US6, FR-028/029* | Archive/hide; `MESSAGES` audit domain + `log_message_event`. | None |
+| **P6** | Caregiver archive + MESSAGE audit domain — *US6, FR-028/029* | Archive/hide; `MESSAGE` audit domain (`message`) + `log_message_event`. | None |
 | **P7** | Cutover + flag enablement | Enable caregiver feature flag; route existing admin email workflows through message creation (FR-026); deprecate-in-place old direct-email path. | **Behavioral switch** — done last, after web/admin ready |
 | **P8 (future)** | Provider webhooks / push channel | Optional: bounce webhook (Q3); push as 2nd channel (reuse push infra). | Out of v1 |
 

--- a/specs/032-message-center/research.md
+++ b/specs/032-message-center/research.md
@@ -125,8 +125,8 @@ channel-aware, versioned communication templates (area 2). Everything else is re
   `log_email_event(...)` and domain helpers.
 - `app/repository/audit_event_repository.py` — append-only, container `audit_events`,
   partition `/patient_id`.
-- **Decision**: per FR-028, the Message Center is **separate** from audit. Add a communications
-  audit domain (e.g. `MESSAGES` / `COMMUNICATION`) and `log_message_event(...)` helper for
+- **Decision**: per FR-028, the Message Center is **separate** from audit. Add a MESSAGE
+  audit domain (`AuditDomain.MESSAGE`, enum value `message`) and `log_message_event(...)` helper for
   lifecycle events (created/delivered/read/resent/archived). Messages are user-facing records;
   audit stays internal. A message MAY carry an audit correlation id.
 
@@ -160,7 +160,7 @@ channel-aware, versioned communication templates (area 2). Everything else is re
   send time guarantees reproducibility (D-comply with i18n "structured codes" platform rule).
 - **D4 — Reuse campaign lifecycle for bulk** (FR-019): campaigns fan out to Messages, not raw
   emails; idempotency/retry already present.
-- **D5 — Audit stays separate** (FR-028): new comms audit domain; Message Center is not the
+- **D5 — Audit stays separate** (FR-028): new MESSAGE audit domain (`message`); Message Center is not the
   audit log.
 - **D6 — Channel-agnostic delivery**: email is the only v1 channel; push infra already exists and
   slots in later as a second channel with no message-model change.

--- a/specs/032-message-center/spec.md
+++ b/specs/032-message-center/spec.md
@@ -389,7 +389,8 @@ still retrievable via an archived filter, and still present for audit/retention.
   user-facing communications; audit events store internal system/admin events. A message MAY be
   linked to an audit event but the two MUST remain distinct concepts.
 - **FR-029**: The system MUST emit audit events for message lifecycle (created, delivered,
-  read, resent, archived) under a communications audit domain, without storing PHI unnecessarily.
+  read, resent, archived) under a dedicated MESSAGE audit domain (`AuditDomain.MESSAGE`, enum
+  value `message`), without storing PHI unnecessarily.
 - **FR-030**: Email bodies (and future push payloads) MUST avoid unnecessary clinical detail;
   sensitive context SHOULD live behind authentication in the in-app message. A future push, when
   added, MUST be generic (e.g. "You have a new message in rettX").


### PR DESCRIPTION
Reconciles stale wording in the Message Center umbrella spec to the **authoritative shipped value**.

**Why:** rettxapi ships `AuditDomain.MESSAGE = message ` (verified in `app/models/core/audit_event.py`). The spec docs still referred to a *communications* / *comms* audit domain, with `MESSAGES` / `COMMUNICATION` placeholders in research/plan. This surfaced while wiring the rettxadmin Audit Trail UI, whose domain config keys off the literal `message` value.

**Changes (docs only):**
- `spec.md` FR-029 - now names the **MESSAGE audit domain** (`AuditDomain.MESSAGE`, enum value `message`).
- `research.md` - decision + D5 updated from 'communications audit domain (e.g. MESSAGES / COMMUNICATION)' to the shipped `MESSAGE` / `message`.
- `plan.md` - infra note + P6 row updated to `MESSAGE` / `message`.

No contract-surface change; no behavioral change. Aligns umbrella spec ↔ backend enum ↔ downstream UI config.