### PR TITLE
adr(0003): in-app vs email content model for Message Center

### DIFF
--- a/.specify/memory/patterns.md
+++ b/.specify/memory/patterns.md
@@ -129,6 +129,22 @@ courtesy, not a security control.
 - New caregiver-facing features ship with the full supported language set,
   even if some translations are placeholder pending review.
 
+### Message templates & channel content
+
+- Transactional content (e.g. the Message Center) is authored as per-locale
+  templates in the **`templates`** content repo, one folder per message type
+  (e.g. `emails/welcome/<locale>.html` + `<locale>.subject.txt`).
+- A single message renders to **per-channel** content captured in an immutable
+  snapshot at send time: a rich **email** HTML body and a plaintext **in-app**
+  body (plus a derived preview). Email and in-app content MAY intentionally
+  diverge.
+- In-app body resolution precedence: `<locale>.inapp.txt` →
+  `<locale>.text.txt` → cleaned `html_to_text(<locale>.html)`. Author a
+  dedicated `<locale>.inapp.txt` **only** where the email is a poor in-app fit
+  (heavy chrome / CTA buttons); otherwise the clean auto-derived text is used.
+  HTML→text derivation MUST strip `<style>`/`<script>` blocks. See
+  [ADR 0003](../../docs/adr/0003-message-channel-content-model.md).
+
 ## 6. Issue routing labels
 
 These labels are managed (largely) by **Iris** in the `rettx` repo. They
@@ -222,3 +238,4 @@ issue is `cross-cutting`, it goes through gap analysis → umbrella spec →
 |---|---|
 | 2026-05-01 | Initial version (1.0.0). |
 | 2026-06-22 | §6/§7: cross-cutting work goes via gap-analysis → umbrella spec → `spec-fanout` (frontmatter `fanout:`, not `tasks.md`); `/route confirm` reserved for single-repo work (ADR 0002). |
+| 2026-06-23 | §5: added message templates & channel content (in-app vs email, `inapp.*` precedence) per ADR 0003. |

--- a/docs/adr/0003-message-channel-content-model.md
+++ b/docs/adr/0003-message-channel-content-model.md
@@ -1,0 +1,160 @@
+# ADR 0003 — In-app vs email content model for the Message Center
+
+- **Status**: Accepted
+- **Date**: 2026-06-23
+- **Decision-makers**: rettX maintainers
+- **Relates to**: [`specs/032-message-center/`](../../specs/032-message-center/spec.md)
+  (rendering & content-snapshot requirements), [ADR 0001](0001-control-plane-repo.md)
+
+## Context
+
+The Message Center (spec 032) introduces **persistent in-app messages** alongside
+the pre-existing **transactional email** channel. The same logical message (e.g.
+"welcome") must now be presented in two very different surfaces: a caregiver's
+in-app Message Center *and* an email inbox.
+
+Email content is authored as per-locale templates in the **`templates`** content
+repo, one folder per message type:
+
+```
+emails/welcome/
+  en.html           ← rich, branded HTML email (has <style>, header, footer,
+  en.subject.txt       unsubscribe, CTA buttons) — one per locale
+  de.html
+  de.subject.txt
+  …                 ← ~24 locales
+```
+
+Under the new model, sending a message captures an **immutable content snapshot**
+at send time (SC-008) with per-channel fields on the message record:
+
+| Snapshot field | Feeds | Channel |
+|---|---|---|
+| `subject` | email subject | email |
+| `email_html_body` | the styled HTML | **email** |
+| `in_app_body` | the Message Center detail body | **in-app** |
+| `preview` | a truncation of `in_app_body` | in-app list snippet |
+
+The backend renderer (`rettxapi` `MessageRenderingServices.render`) resolves
+`in_app_body` by precedence:
+
+```
+<locale>.inapp.txt   (dedicated in-app template)
+   └─ else <locale>.text.txt   (plaintext email template)
+        └─ else  html_to_text(<locale>.html)   (derive from the email HTML)
+```
+
+**Today, templates ship only `<locale>.html` + `<locale>.subject.txt`.** No
+in-app or plaintext file exists, so `in_app_body` *always* falls through to the
+HTML→text fallback. That converter strips `<tags>` but historically left the
+inner text of `<style>`/`<script>` blocks behind, so the email stylesheet leaked
+into the in-app body and list preview. Observed on the live welcome message:
+
+> "Welcome to rettX, the European Rett Syndrome patient registry body {
+> font-family: 'Chillax', 'Helvetica Neue', Helvetica, Arial, sans-serif; … }"
+
+This exposed two separate questions: (1) a rendering **bug**, and (2) a
+**strategic** question — should in-app and email content be the same copy in two
+renderings, or intentionally diverge?
+
+## Decision
+
+Adopt a **hybrid channel-content model**:
+
+1. **Default = auto-derive clean in-app text.** When a template has no dedicated
+   in-app file, `in_app_body` is derived from the email template as **clean
+   plaintext**. The HTML→text conversion MUST remove entire `<style>…</style>`
+   and `<script>…</script>` blocks (including inner content) *before* stripping
+   remaining tags. This is the v1 floor and requires no template authoring.
+
+2. **Per-channel authoring on demand.** A template MAY add a dedicated in-app
+   body file **`<locale>.inapp.txt`** (plaintext; markdown is a possible future
+   enhancement). When present, the renderer uses it **verbatim** instead of
+   deriving from the email HTML — letting in-app and email content **intentionally
+   diverge** (in-app: short, no email chrome, app deep-links; email: full branded
+   HTML).
+
+3. **Authoring policy (the "hybrid" rule).** Author `<locale>.inapp.txt` **only
+   where the email is a poor in-app fit** — heavy chrome, CTA buttons, or
+   email-specific framing (e.g. `welcome`, `invitation_email`). Everything else
+   relies on the clean auto-derived text. Adopt incrementally and revisit once
+   the feature is live in production.
+
+4. **Defense in depth on the leak.** Because content snapshots are immutable, the
+   already-sent welcome message keeps its polluted `in_app_body`. The fix is
+   therefore applied at **three** layers:
+   - **Source** — the renderer strips `<style>`/`<script>` before tag-stripping
+     (fixes all *new* messages).
+   - **Read-time guard** — the API model sanitises `preview`/`body` on read
+     (fixes *existing* snapshots without a data migration).
+   - **Frontend** — `rettxweb` keeps its `cleanPreview`/`cleanBody` utilities as
+     a belt-and-suspenders third layer.
+
+5. **No API contract change.** Caregiver `body`/`preview` remain plaintext; the
+   email channel is unchanged. The snapshot stays the single immutable record of
+   what was actually sent.
+
+### Channel content matrix
+
+| Channel | Source (in precedence order) | Format | Authored where |
+|---|---|---|---|
+| Email | `<locale>.html` + `<locale>.subject.txt` | rich HTML | `templates` repo |
+| In-app body | `<locale>.inapp.txt` → `<locale>.text.txt` → cleaned `html_to_text(<locale>.html)` | plaintext | `templates` repo / derived |
+| In-app preview | truncation of `in_app_body` | plaintext | derived |
+
+## Alternatives considered
+
+### A. Auto-derive only — never author in-app templates
+
+Rejected as the *sole* long-term answer. Email copy (unsubscribe footers, CTA
+buttons, "view in browser") reads poorly in-app and cannot be tailored. Retained,
+however, as the **default fallback** for templates that extract cleanly.
+
+### B. Always author a dedicated in-app template for every type × locale
+
+Rejected. ~11 message types × ~24 locales is a large, ongoing authoring burden
+for low marginal value on simple messages whose email already extracts to fine
+plaintext. Forcing it would slow every new message type.
+
+### C. Hybrid — clean auto-derivation by default, dedicated in-app copy where it matters
+
+**Chosen.** Gives a clean in-app experience immediately with zero authoring, and
+an opt-in path to tailored in-app copy exactly where the email is a poor fit,
+adopted incrementally.
+
+## Consequences
+
+### Positive
+
+- In-app messages render clean plaintext immediately — the CSS leak is closed at
+  three layers, covering both new and already-stored messages.
+- In-app copy can be tailored per template/locale without touching the email
+  channel or the API contract.
+- The immutable snapshot (SC-008) remains the single source of truth for what was
+  sent; audit/reproducibility is preserved.
+
+### Negative
+
+- For templates where `inapp.*` is authored, there are now **two** content
+  sources to keep in sync (email vs in-app).
+- Authors must understand the rendering precedence to predict which source wins.
+
+### Neutral
+
+- Existing templates need **no** change to benefit from the clean fallback.
+- In-app divergence is strictly **opt-in** per template and per locale.
+
+## Follow-ups
+
+- **`rettxapi`** — ship the renderer source-clean + read-time guard bugfix PR
+  (in flight): strip `<style>`/`<script>` before tag-stripping; cover new and
+  existing snapshots; tests at both layers.
+- **`rettxweb`** — retain the defensive `cleanPreview`/`cleanBody` utilities.
+- **`templates`** — add `<locale>.inapp.txt` for `welcome` and `invitation_email`
+  first (highest email chrome); document the `inapp.*` convention in the repo
+  README and `deploy.ps1` packaging.
+- **`patterns.md`** — channel-content convention + `inapp.*` naming recorded in §5.
+- **`specs/032-message-center/`** — cross-link the rendering requirements to this
+  ADR.
+- Consider adding the `templates` content repo to `patterns.md` §1 (currently
+  undocumented there).


### PR DESCRIPTION
## Summary

Captures the architectural decision (raised while testing the live caregiver Message Center) for **how in-app and email content relate** under the new message model.

**Decision: Option C — hybrid channel-content model.**
- **Default:** in-app body is auto-derived as *clean plaintext* from the per-locale email template (`<locale>.html`) when no dedicated in-app file exists. HTML→text derivation MUST strip `<style>`/`<script>` blocks (the root cause of the observed CSS leak).
- **Opt-in:** a template MAY add `<locale>.inapp.txt` for purpose-authored in-app copy that intentionally diverges from the email (short, no email chrome, app deep-links). Authored **only** where the email is a poor in-app fit (e.g. `welcome`, `invitation_email`); everything else uses the clean auto-derived text.
- **Precedence:** `<locale>.inapp.txt` → `<locale>.text.txt` → cleaned `html_to_text(<locale>.html)`.

## Context

The live `welcome` message rendered as *"Welcome to rettX… body { font-family: 'Chillax'… }"* — the email `<style>` CSS leaked into the in-app body/preview. Root cause: templates ship only `.html` + `.subject.txt`, so `in_app_body` always falls back to an HTML→text converter that stripped tags but kept `<style>` inner text.

## Three-layer fix (defense in depth)

- **rettxapi (in flight):** renderer source-clean + read-time guard (covers new *and* already-stored immutable snapshots).
- **rettxweb (shipped, #168):** defensive `cleanPreview`/`cleanBody` utilities.
- No API contract change; the immutable snapshot (SC-008) stays the source of truth.

## Files

- `docs/adr/0003-message-channel-content-model.md` (new)
- `.specify/memory/patterns.md` — §5 channel-content convention + changelog

Relates to `specs/032-message-center/` and ADR 0001.
