### PR TITLE
docs(spec-process): register `templates` as a routable content repo; fan out push templates

### DIFF
--- a/.github/workflows/iris-route.yml
+++ b/.github/workflows/iris-route.yml
@@ -48,7 +48,7 @@ jobs:
           app-id: ${{ secrets.IRIS_APP_ID }}
           private-key: ${{ secrets.IRIS_PRIVATE_KEY }}
           owner: rett-europe
-          repositories: rettx,rettxweb,rettxadmin,rettxapi,rettxmutation,rettxid
+          repositories: rettx,rettxweb,rettxadmin,rettxapi,rettxmutation,rettxid,templates
 
       - name: Fan out sub-issues
         env:
@@ -77,7 +77,7 @@ jobs:
             exit 0
           fi
 
-          declare -A repo_for=( [route:web]=rettxweb [route:admin]=rettxadmin [route:api]=rettxapi [route:mutation]=rettxmutation [route:id]=rettxid )
+          declare -A repo_for=( [route:web]=rettxweb [route:admin]=rettxadmin [route:api]=rettxapi [route:mutation]=rettxmutation [route:id]=rettxid [route:templates]=templates )
 
           # Collect the route:* labels actually present on the parent.
           mapfile -t parent_labels < <(echo "$existing" | tr ',' '\n')

--- a/.github/workflows/iris-triage.yml
+++ b/.github/workflows/iris-triage.yml
@@ -68,7 +68,7 @@ jobs:
           max-tokens: 600
           system-prompt: |
             You are Iris, the triage assistant for the rettX patient registry program.
-            The program spans 6 GitHub repositories in the rett-europe organisation:
+            The program spans 7 GitHub repositories in the rett-europe organisation:
 
               - rettx           — control plane (this repo). Constitution, cross-cutting specs, ADRs, docs.
               - rettxweb        — caregiver-facing Angular PWA (app.rettx.eu).
@@ -76,6 +76,7 @@ jobs:
               - rettxapi        — Python backend service. The ONLY component that touches identifiable patient data at rest. Owns consent, access control, audit.
               - rettxmutation   — Python library (PyPI). HGVS mutation parsing & normalisation. Used by rettxapi.
               - rettxid         — Python library (PyPI). Pseudonymous patient identifiers. Used by rettxapi.
+              - templates       — Content repo, no app code. Per-locale Message Center templates (email/in-app/push), consent forms, surveys, privacy policies. Deployed to Blob storage and rendered by rettxapi. Route here when the change is to template/content text rather than code.
 
             Given an issue title and body, decide which repositories are affected and whether the change crosses trust
             boundaries (anything touching identifiable data, consent, authZ, or affecting more than one runtime
@@ -83,7 +84,7 @@ jobs:
 
             Respond with strict minified JSON, no prose, no markdown fences:
               {
-                "routes":        ["web"|"admin"|"api"|"mutation"|"id"|"control-plane", ...],
+                "routes":        ["web"|"admin"|"api"|"mutation"|"id"|"templates"|"control-plane", ...],
                 "cross_cutting": boolean,
                 "needs_spec":    boolean,
                 "summary":       "one short sentence",
@@ -119,8 +120,8 @@ jobs:
           rationale=$(echo "$payload"     | jq -r '.rationale // ""')
 
           # Map route keys → label names and human names.
-          declare -A label_for=( [web]=route:web [admin]=route:admin [api]=route:api [mutation]=route:mutation [id]=route:id )
-          declare -A name_for=(  [web]=rettxweb  [admin]=rettxadmin  [api]=rettxapi  [mutation]=rettxmutation  [id]=rettxid )
+          declare -A label_for=( [web]=route:web [admin]=route:admin [api]=route:api [mutation]=route:mutation [id]=route:id [templates]=route:templates )
+          declare -A name_for=(  [web]=rettxweb  [admin]=rettxadmin  [api]=rettxapi  [mutation]=rettxmutation  [id]=rettxid  [templates]=templates )
 
           labels_to_add=("triaged")
           targets=()

--- a/.github/workflows/spec-fanout.yml
+++ b/.github/workflows/spec-fanout.yml
@@ -45,7 +45,7 @@ jobs:
           app-id: ${{ secrets.IRIS_APP_ID }}
           private-key: ${{ secrets.IRIS_PRIVATE_KEY }}
           owner: rett-europe
-          repositories: rettx,rettxweb,rettxadmin,rettxapi,rettxmutation,rettxid
+          repositories: rettx,rettxweb,rettxadmin,rettxapi,rettxmutation,rettxid,templates
 
       - name: Check out rettx at the merge commit
         uses: actions/checkout@v4
@@ -84,7 +84,7 @@ jobs:
           set -euo pipefail
           python -m pip install --quiet "PyYAML==6.0.2"
 
-          ALLOWED_REPOS="rettxweb rettxadmin rettxapi rettxmutation rettxid"
+          ALLOWED_REPOS="rettxweb rettxadmin rettxapi rettxmutation rettxid templates"
 
           while IFS= read -r spec_path; do
             [[ -z "$spec_path" ]] && continue

--- a/.specify/memory/patterns.md
+++ b/.specify/memory/patterns.md
@@ -11,7 +11,7 @@ adopted, and reference it from cross-cutting specs.
 
 ## 1. Repositories and roles
 
-The ecosystem has **four kinds** of repository. They are governed by the same
+The ecosystem has **five kinds** of repository. They are governed by the same
 program constitution but differ in lifecycle and deployment model.
 
 ### Control plane
@@ -62,6 +62,27 @@ Library lifecycle differs from the surfaces and backend:
   `rettxapi` version bump that consumes the new release.
 - Library issues are accepted directly in their own repos for
   library-internal concerns; cross-cutting work is still authored here.
+
+### Content (deployed template & document assets)
+
+`templates` holds **no application code** — it is the source of truth for the
+per-locale transactional **content** the surfaces and backend render.
+
+| Repo | Visibility | Purpose | Deploys to |
+|---|---|---|---|
+| [`templates`](https://github.com/rett-europe/templates) | 🔒 Private | Per-locale Message Center templates (`emails/<type>/<locale>.*`), plus consent forms, privacy policies, surveys, and Auth0 email templates | Azure Blob `email-templates` container, via its own GitHub Actions deploy (`deploy-email-templates.yml`, `az storage blob sync` on merge to `main`) |
+
+Content lifecycle differs from the code repos:
+
+- Templates are **rendered, not imported.** `rettxapi` reads them from the blob
+  container at send time by path (`<type>/<locale>.<suffix>`). A **missing file
+  for a channel means that channel is silently skipped** at render — so shipping
+  a new channel (e.g. push) requires authoring its template files **here**, not
+  only the rendering code in `rettxapi`. A spec that adds a channel MUST fan a
+  slice out to `templates`.
+- Deploy is a **full sync with delete** (`--delete-destination true`): the blob
+  container mirrors `emails/` exactly. Manual blob edits are transient and are
+  wiped on the next deploy — every template change MUST land in this repo.
 
 ## 2. Shared vocabulary
 
@@ -154,6 +175,14 @@ courtesy, not a security control.
   (heavy chrome / CTA buttons); otherwise the clean auto-derived text is used.
   HTML→text derivation MUST strip `<style>`/`<script>` blocks. See
   [ADR 0003](../../docs/adr/0003-message-channel-content-model.md).
+- **Push channel** (spec 033) renders from `<locale>.push.subject.txt` (title)
+  and `<locale>.push.txt` (body), resolved by the recipient's profile language
+  with **English fallback** (`<locale>` → `en`). Push text is intentionally
+  **generic and free of PHI** — it is a nudge, never the message body (which
+  lives in the in-app record and email). A template with **no** `push.*` files
+  renders empty `push_title`/`push_body` and the push channel is **skipped** for
+  that message (email + in-app unaffected). Author `push.*` files in the
+  **`templates`** repo for every Message Center template that should notify.
 
 ## 6. Issue routing labels
 
@@ -168,6 +197,7 @@ form the contract between intake and execution.
 | `route:api` | Should land in `rettxapi` | Iris |
 | `route:mutation` | Should land in `rettxmutation` | Iris |
 | `route:id` | Should land in `rettxid` | Iris |
+| `route:templates` | Should land in `templates` (content assets) | Iris |
 | `cross-cutting` | Affects more than one repo | Iris |
 | `triaged` | Iris has classified; awaiting maintainer routing | Iris |
 | `routed` | Maintainer confirmed `/route`; downstream issues opened | Iris |
@@ -220,7 +250,10 @@ issue is `cross-cutting`, it goes through gap analysis → umbrella spec →
   each entry is `{ repo, summary }` — and opens one `[spec/<slug>]` squad issue
   per listed repo on merge. Fan-out runs **only** when the spec's `status` is
   `ready` or `accepted`; a `draft` spec never fans out. Allowed repos:
-  `rettxweb, rettxadmin, rettxapi, rettxmutation, rettxid`.
+  `rettxweb, rettxadmin, rettxapi, rettxmutation, rettxid, templates`.
+  A spec that adds or changes **rendered content** (email/in-app/push templates,
+  consent forms, surveys) MUST include a `templates` fan-out slice — the
+  rendering repo (`rettxapi`) consumes template files but does not author them.
 - Single-repo work does not require a cross-cutting spec; it can flow
   directly through the downstream repo's local spec-kit workflow (reached via
   the `/route confirm` path — see §6).
@@ -261,3 +294,4 @@ issue is `cross-cutting`, it goes through gap analysis → umbrella spec →
 | 2026-06-22 | §6/§7: cross-cutting work goes via gap-analysis → umbrella spec → `spec-fanout` (frontmatter `fanout:`, not `tasks.md`); `/route confirm` reserved for single-repo work (ADR 0002). |
 | 2026-06-23 | §5: added message templates & channel content (in-app vs email, `inapp.*` precedence) per ADR 0003. |
 | 2026-07-07 | §1: recorded that `rettxweb` is a **Capacitor native app** (Android pilot; native FCM device tokens) in addition to the PWA, plus a *Delivery targets* note. §7: added the rule that specs must verify each fanout repo's delivery/platform mechanism against the §1 registry (and update §1 in the same PR) before `status: ready`. Prompted by spec 033 (Message Center push). |
+| 2026-07-11 | §1: registered the **`templates`** content repo as a first-class ecosystem repo (fifth kind — *Content*; deploys to the `email-templates` blob via its own CI, full sync with delete). §5: documented the **push** channel template files (`<locale>.push.subject.txt`/`.push.txt`, English fallback, generic/no-PHI) and the "missing template ⇒ channel skipped" rule. §6/§7: added the `route:templates` label, put `templates` in the fan-out allow-list, and required content-adding specs to fan a slice out to `templates`. Prompted by spec 033 push templates never being authored because `templates` was not a routable/fan-out repo — rendering shipped in `rettxapi` but the `push.*` files never existed, so push was silently skipped. |

--- a/specs/033-message-center-push/spec.md
+++ b/specs/033-message-center-push/spec.md
@@ -4,7 +4,7 @@
   repos get a `[spec/<slug>] <title>` issue with the `squad` label. Set
   `status: ready` when this spec should fan out on merge — drafts will not.
 
-  Allowed fanout repos: rettxweb, rettxadmin, rettxapi, rettxmutation, rettxid.
+  Allowed fanout repos: rettxweb, rettxadmin, rettxapi, rettxmutation, rettxid, templates.
 
   STACK & DELIVERY PRE-FLIGHT (patterns.md §7): each fanout repo's delivery
   mechanism was verified against patterns.md §1. rettxweb is a Capacitor native
@@ -37,9 +37,13 @@ fanout:
       **identity mapping**: device tokens are keyed on Auth0 `user_id`, but message
       recipients are `principal_id` — add a principal → linked identities → active
       tokens resolver in the push path. Add `push_title`/`push_body` to
-      `ContentSnapshot` and `push.subject.txt`/`push.txt` versioned template
-      suffixes, rendered by the recipient's **profile language** (032 D1) with
-      English fallback. The push capability is **available to all**
+      `ContentSnapshot` and **render** the `push.subject.txt`/`push.txt` template
+      suffixes by the recipient's **profile language** (032 D1) with English
+      fallback. NOTE: the push template *files* are authored in the **`templates`**
+      content repo (see its fan-out slice below) — this slice only reads and renders
+      them; it does NOT create template content. A message whose template has no
+      `push.*` files renders empty push fields and the push channel is skipped.
+      The push capability is **available to all**
       caregivers (the `push_notification` flag is force-on, mirroring
       `messages`); delivery is naturally gated by **active device-token
       presence** — resolve `principal_id → identities → active tokens` and
@@ -82,6 +86,27 @@ fanout:
       to the Message Center (keyed off Auth0 `user_id`, not `principal_id`) and must
       not be confused with the MC push channel. No new per-user toggle is needed;
       push consent is device-enforced (OS opt-in / active-token presence).
+  - repo: templates
+    summary: |
+      Author the **push channel template files** — without these, `rettxapi`
+      renders empty push content and the channel is silently skipped (this is the
+      slice that makes push actually fire). For each Message Center email-template
+      folder under `emails/<type>/`, add `<locale>.push.subject.txt` (push title)
+      and `<locale>.push.txt` (push body). **English (`en.push.*`) is the minimum
+      required** — the renderer falls back to English when a localized push file is
+      absent; localized files can follow later. Keep push text **generic and
+      PHI-free**: it is a nudge (e.g. title "New message", body "You have a new
+      message from rettX. Tap to open."), never the message body, which lives in
+      the in-app record + email (FR-014). Cover every template the admin can send —
+      the source of truth is `rettxadmin` `TEMPLATE_CATEGORY_MAP`
+      (`src/app/models/message.ts`): at least `welcome`, `missing_name`,
+      `missing_surname`, `missing_dob`, `info_mismatch_name`, `info_mismatch_dob`,
+      `missing_mutation_in_report`, `no_rett_diagnosis`, `reminder_genetics`, and
+      `information_request_custom`. Merging to `main` runs
+      `deploy-email-templates.yml` (`az storage blob sync --delete-destination`),
+      which publishes the files to the `email-templates` blob container `rettxapi`
+      renders from — so the push files MUST live in this repo; a manual blob upload
+      would be wiped on the next sync.
 ---
 
 # Feature Specification: rettX Message Center — Push Notifications


### PR DESCRIPTION
## Why

Spec **033 (Message Center push)** shipped push *rendering* in `rettxapi`, but the push template files (`<locale>.push.subject.txt` / `.push.txt`) were **never authored** — so every Message Center message renders empty push content and the push channel is **silently skipped** (email + in-app still work). This is exactly the symptom hit in the pilot: email arrived, push did not.

**Root cause is a process gap, not a code bug.** The `templates` repo — the content source of truth that owns rendered email/in-app/push assets and deploys them to the `email-templates` blob via its own CI — was **not a first-class ecosystem repo**. It was absent from the repo registry, the routing labels, the fan-out allow-list, and Iris routing, so no spec could fan a slice out to it. Spec 033 therefore mis-assigned "author the `push.*` template files" to the `rettxapi` slice, which only *renders* them.

## What this PR does

Registers `templates` as a first-class repo and makes content-adding specs route to it. **Control-plane governance only — no template content and no constitution changes.**

- **`patterns.md`**
  - §1: add `templates` as a **fifth repo kind — _Content_** (deploys to the `email-templates` blob via `deploy-email-templates.yml`, full sync with delete).
  - §5: document the **push channel** template files (`<locale>.push.subject.txt` / `.push.txt`, English fallback, generic/no-PHI) and the **"missing template ⇒ channel skipped"** rule.
  - §6/§7: add the `route:templates` label, put `templates` in the fan-out allow-list, and require content-adding specs to fan a slice out to `templates`.
  - §10: changelog entry.
- **Iris workflows** (`spec-fanout.yml`, `iris-route.yml`, `iris-triage.yml`): add `templates` to the app token scope, the fan-out allow-list, the triage classifier + route enum/maps, and the `/route confirm` repo map (`route:templates → templates`).
- **spec 033**: add a `templates` fan-out slice that authors the push template files (English minimum, generic/no-PHI, list of MC templates); correct the `rettxapi` slice to note it only *renders* — it does not author — those files.

## Effect on merge

`spec-fanout` re-runs idempotently and opens one new `[spec/033-...]` `squad` issue in **`templates`** (existing issues in the other repos are untouched). That issue is picked up to add the actual `push.*` files (Part B), which deploy to blob and make push render.

## Not in scope

- The push template **content** itself (Part B, in the `templates` repo).
- `constitution.md` — intentionally left untouched; repo facts live in `patterns.md`.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>