### PR TITLE
docs(adr): 0006 — Message Center template store layout & naming (Proposed)

### DIFF
--- a/.specify/memory/patterns.md
+++ b/.specify/memory/patterns.md
@@ -70,7 +70,7 @@ per-locale transactional **content** the surfaces and backend render.
 
 | Repo | Visibility | Purpose | Deploys to |
 |---|---|---|---|
-| [`templates`](https://github.com/rett-europe/templates) | 🔒 Private | Per-locale Message Center templates (`emails/<type>/<locale>.*`), plus consent forms, privacy policies, surveys, and Auth0 email templates | Azure Blob `email-templates` container, via its own GitHub Actions deploy (`deploy-email-templates.yml`, `az storage blob sync` on merge to `main`) |
+| [`templates`](https://github.com/rett-europe/templates) | 🔒 Private | Per-locale Message Center message templates (`messages/<type>/<locale>.<suffix>`), plus consent forms, privacy policies, surveys, and Auth0 email templates | Azure Blob `email-templates` container, via its own GitHub Actions deploy (`deploy-email-templates.yml`, `az storage blob sync` on merge to `main`) |
 
 Content lifecycle differs from the code repos:
 
@@ -81,8 +81,16 @@ Content lifecycle differs from the code repos:
   only the rendering code in `rettxapi`. A spec that adds a channel MUST fan a
   slice out to `templates`.
 - Deploy is a **full sync with delete** (`--delete-destination true`): the blob
-  container mirrors `emails/` exactly. Manual blob edits are transient and are
-  wiped on the next deploy — every template change MUST land in this repo.
+  container mirrors the source folder exactly. Manual blob edits are transient
+  and are wiped on the next deploy — every template change MUST land in this repo.
+- The Message Center message templates live under **`messages/`** (renamed from
+  `emails/` per [ADR 0006](../../docs/adr/0006-message-center-template-store-layout.md),
+  since they now carry email **and** in-app **and** push content). The deploy
+  strips the folder prefix, so the blob container is still named `email-templates`
+  and `rettxapi` (which reads by `<type>/<locale>.<suffix>`) is unaffected by the
+  rename. Per-channel file suffixes: `<locale>.html` + `<locale>.subject.txt`
+  (email), `<locale>.inapp.txt` (optional dedicated in-app body),
+  `<locale>.push.subject.txt` + `<locale>.push.txt` (push).
 
 ## 2. Shared vocabulary
 
@@ -164,7 +172,9 @@ courtesy, not a security control.
 
 - Transactional content (e.g. the Message Center) is authored as per-locale
   templates in the **`templates`** content repo, one folder per message type
-  (e.g. `emails/welcome/<locale>.html` + `<locale>.subject.txt`).
+  (e.g. `messages/welcome/<locale>.html` + `<locale>.subject.txt`). The folder is
+  `messages/` (not `emails/`) because a message renders to email, in-app and push
+  — see [ADR 0006](../../docs/adr/0006-message-center-template-store-layout.md).
 - A single message renders to **per-channel** content captured in an immutable
   snapshot at send time: a rich **email** HTML body and a plaintext **in-app**
   body (plus a derived preview). Email and in-app content MAY intentionally
@@ -295,3 +305,4 @@ issue is `cross-cutting`, it goes through gap analysis → umbrella spec →
 | 2026-06-23 | §5: added message templates & channel content (in-app vs email, `inapp.*` precedence) per ADR 0003. |
 | 2026-07-07 | §1: recorded that `rettxweb` is a **Capacitor native app** (Android pilot; native FCM device tokens) in addition to the PWA, plus a *Delivery targets* note. §7: added the rule that specs must verify each fanout repo's delivery/platform mechanism against the §1 registry (and update §1 in the same PR) before `status: ready`. Prompted by spec 033 (Message Center push). |
 | 2026-07-11 | §1: registered the **`templates`** content repo as a first-class ecosystem repo (fifth kind — *Content*; deploys to the `email-templates` blob via its own CI, full sync with delete). §5: documented the **push** channel template files (`<locale>.push.subject.txt`/`.push.txt`, English fallback, generic/no-PHI) and the "missing template ⇒ channel skipped" rule. §6/§7: added the `route:templates` label, put `templates` in the fan-out allow-list, and required content-adding specs to fan a slice out to `templates`. Prompted by spec 033 push templates never being authored because `templates` was not a routable/fan-out repo — rendering shipped in `rettxapi` but the `push.*` files never existed, so push was silently skipped. |
+| 2026-07-11 | §1/§5: renamed the Message Center template folder `emails/` → **`messages/`** ([ADR 0006](../../docs/adr/0006-message-center-template-store-layout.md), Accepted) since it now carries email + in-app + push content; documented the per-channel file-suffix convention. Deploy strips the folder prefix, so the blob container stays `email-templates` and `rettxapi` is unaffected. |

--- a/docs/adr/0006-message-center-template-store-layout.md
+++ b/docs/adr/0006-message-center-template-store-layout.md
@@ -1,6 +1,6 @@
 # ADR 0006 — Message Center template store: multi-channel layout & naming
 
-- **Status**: Proposed
+- **Status**: Accepted (2026-07-11)
 - **Date**: 2026-07-11
 - **Decision-makers**: rettX maintainers
 - **Relates to**: [ADR 0003](0003-message-channel-content-model.md) (channel
@@ -122,9 +122,10 @@ and avoids the sync-with-delete cutover hazard. Record the per-channel file
 convention explicitly (this ADR + a `templates` README + `patterns.md` §5) so the
 naming is self-documenting regardless of the folder label.
 
-> This ADR is **Proposed**. It does not itself perform any rename — on
-> acceptance, the folder rename fans out as a `templates` slice, and the
-> convention documentation updates land in `patterns.md`.
+> This ADR is **Accepted** (2026-07-11). The `patterns.md` convention/`messages/`
+> documentation lands with this ADR (control-plane PR #27); the folder rename
+> itself is executed as a `templates` repo slice (its own PR) — the container and
+> blob paths are unchanged, so `rettxapi` needs no change.
 
 ## Consequences
 

--- a/docs/adr/0006-message-center-template-store-layout.md
+++ b/docs/adr/0006-message-center-template-store-layout.md
@@ -1,0 +1,158 @@
+# ADR 0006 — Message Center template store: multi-channel layout & naming
+
+- **Status**: Proposed
+- **Date**: 2026-07-11
+- **Decision-makers**: rettX maintainers
+- **Relates to**: [ADR 0003](0003-message-channel-content-model.md) (channel
+  content model), [`specs/032-message-center/`](../../specs/032-message-center/spec.md),
+  [`specs/033-message-center-push/`](../../specs/033-message-center-push/spec.md)
+  (push channel), [`patterns.md` §1 *Content* / §5](../../.specify/memory/patterns.md)
+
+## Context
+
+The `templates` content repo (`rett-europe/templates`) holds the per-locale
+Message Center message templates. They live in a top-level folder called
+**`emails/`**, one subfolder per message type:
+
+```
+emails/welcome/
+  en.html                 ← branded HTML email body
+  en.subject.txt          ← email subject
+  en.inapp.txt            ← (optional, ADR 0003) dedicated in-app body
+  en.push.subject.txt     ← (new, spec 033) push title
+  en.push.txt             ← (new, spec 033) push body
+```
+
+When the folder was created (spec 032) it held only email content, so `emails/`
+was an accurate name. It has since become the store for **all three Message
+Center channels** — email, in-app (ADR 0003), and now Android **push** (spec
+033). The folder name `emails/` is therefore now a **misnomer**: it holds
+multi-channel message content, not just emails. The same is true of the blob
+**container** it deploys to, `email-templates`.
+
+This ADR exists because that misnomer surfaced during the push rollout and
+raised a fair question: *should the template store be refactored?* Before
+answering, it is essential to separate what is **cosmetic** from what is
+**load-bearing**, because they carry very different migration cost and risk.
+
+### What is actually coupled (and what is not)
+
+The deploy is a **full sync with delete**
+(`templates/.github/workflows/deploy-email-templates.yml`):
+
+```
+az storage blob sync --source ./emails --container email-templates \
+    --delete-destination true
+```
+
+- The **`emails/` prefix is stripped at deploy.** `emails/welcome/en.html`
+  becomes blob `welcome/en.html`. The source folder name **never reaches the
+  blob store or `rettxapi`** — it is a pure repo-local label.
+- **`rettxapi` reads from the blob container** (`email-templates`, configured via
+  env `RETTX_STORAGE_EMAIL_TEMPLATE_CONTAINER`) by the path convention
+  `<type>/<locale>.<suffix>`. It has no knowledge of the `emails/` folder.
+- Because the sync uses `--delete-destination true`, **the container mirrors the
+  source exactly**: any change to the *blob path layout* (not just the folder
+  name) is applied destructively — old paths are deleted on the next deploy.
+
+This gives three distinct levers, in ascending order of cost:
+
+| Lever | What changes | Touches `rettxapi`? | Blob paths change? | Risk |
+|---|---|---|---|---|
+| **(a)** Source folder `emails/` → e.g. `messages/` | repo label + deploy `--source` path + `deploy.ps1` | No | No (prefix stripped either way) | Trivial |
+| **(b)** File-naming convention (e.g. group by channel) | blob paths + `rettxapi` resolver | **Yes** | **Yes** | High (see migration hazard) |
+| **(c)** Blob container `email-templates` → e.g. `message-templates` | container + `rettxapi` env in every environment + data migration | **Yes** | n/a | High (cross-repo, multi-env) |
+
+### Migration hazard (why (b)/(c) are not free)
+
+`--delete-destination true` means a blob-path restructure is **not** additive: on
+the first deploy after the change, the *old* paths are deleted while `rettxapi`
+in production still expects them. Any restructure of blob paths or the container
+name therefore requires a **coordinated cutover** — `rettxapi` must be able to
+read the new layout **before** the templates repo deploys it — or a dual-read /
+dual-write window. This is the core reason the current flat `<type>/<locale>.<suffix>`
+convention is worth preserving unless there is a strong driver to change it.
+
+## Decision drivers
+
+- **Clarity** — a newcomer should not read `emails/` and assume it is email-only.
+- **Low migration risk** — avoid destructive, cross-repo, multi-environment
+  changes for cosmetic gain, especially mid-pilot.
+- **Channel-extensibility** — the scheme should absorb a *fourth* channel later
+  without another migration. (It already absorbed push cleanly via the
+  `.push.` infix.)
+- **Backward compatibility** — the push fix (spec 033) just shipped under the
+  current convention; a refactor must not regress it.
+- **Consistency with governance** — `templates` is now a first-class routable
+  repo (`patterns.md` §1 *Content*); changes to its contract flow through spec +
+  ADR, not ad-hoc renames.
+
+## Options
+
+### Option 0 — Status quo (keep `emails/` + flat suffix convention)
+No change. `emails/` stays a mild misnomer; the flat `<type>/<locale>.<suffix>`
+convention (with `.subject.txt`, `.inapp.txt`, `.push.subject.txt`, `.push.txt`
+infixes) continues. Zero risk, zero clarity gain.
+
+### Option 1 — Rename the source folder only (`emails/` → `messages/`) **[recommended]**
+Rename the repo folder and update `--source ./emails` (deploy workflow) and
+`deploy.ps1`. Blob paths and the container name are **unchanged** (prefix is
+stripped), so `rettxapi` is untouched and there is no cutover. Pure clarity win;
+the folder name finally reflects "multi-channel Message Center message content".
+Optionally add a repo `README` documenting the per-channel file convention.
+
+### Option 2 — Restructure to a channel-grouped layout
+e.g. `<type>/<locale>/{email.html,email.subject.txt,inapp.txt,push.title.txt,push.body.txt}`.
+Cleaner mental model, but changes **blob paths** → requires a `rettxapi` resolver
+change and a coordinated destructive cutover (see hazard). Higher value, much
+higher cost; only justified if the flat convention becomes genuinely unwieldy.
+
+### Option 3 — Rename the blob container (`email-templates` → `message-templates`)
+The most "correct" rename, but the most expensive: container migration plus
+`rettxapi` env changes across dev/pre/prod and a redeploy. Low ROI for a name
+that is invisible to end users.
+
+## Recommendation
+
+Adopt **Option 1 now** (rename the source folder to `messages/`, container and
+blob layout unchanged) as a cheap, zero-risk clarity fix, and **defer Options 2
+and 3** unless a concrete need arises. Keep the flat `<type>/<locale>.<suffix>`
+file convention: it is channel-extensible (it absorbed push without a migration)
+and avoids the sync-with-delete cutover hazard. Record the per-channel file
+convention explicitly (this ADR + a `templates` README + `patterns.md` §5) so the
+naming is self-documenting regardless of the folder label.
+
+> This ADR is **Proposed**. It does not itself perform any rename — on
+> acceptance, the folder rename fans out as a `templates` slice, and the
+> convention documentation updates land in `patterns.md`.
+
+## Consequences
+
+### Positive
+- The store name reflects reality (multi-channel), removing the `emails/`
+  misnomer with no runtime risk.
+- The load-bearing coupling (blob container + flat path convention consumed by
+  `rettxapi`) is preserved, so nothing has to be re-authored or migrated.
+- The per-channel file convention becomes documented and self-explanatory.
+
+### Negative
+- A folder rename touches every path in the `templates` repo's deploy config and
+  any local tooling that hard-codes `emails/` (small, contained).
+- The container name `email-templates` remains a residual misnomer (accepted;
+  Option 3 deferred).
+
+### Neutral
+- No `rettxapi` change and no blob migration under the recommended option.
+- Options 2/3 remain available later behind a proper coordinated cutover if the
+  flat convention or container name ever becomes a real pain point.
+
+## Follow-ups (on acceptance)
+- **`templates`** — rename `emails/` → `messages/`; update
+  `deploy-email-templates.yml` (`--source`) and `deploy.ps1`; add a `README`
+  documenting the `<type>/<locale>.<suffix>` per-channel convention
+  (`.html`, `.subject.txt`, `.inapp.txt`, `.push.subject.txt`, `.push.txt`).
+- **`patterns.md`** — §1 *Content* / §5: note the folder is `messages/` and
+  record the per-channel file-suffix convention explicitly.
+- **`rettxapi`** — no change required under Option 1 (documentation cross-link
+  only). If Options 2/3 are ever adopted, that work is gated on a coordinated
+  resolver/env cutover captured in a superseding ADR.


### PR DESCRIPTION
## ADR 0006 — Message Center template store layout & naming (Accepted)

Accepts ADR 0006 and documents the outcome in `patterns.md`.

**Decision:** rename the Message Center template **source folder** `emails/` → `messages/` (Option 1). The blob deploy strips the folder prefix, so:
- the Azure Blob **container stays `email-templates`** (unchanged),
- **blob paths are unchanged**, so **`rettxapi` needs no change** and there is no blob migration.

### What's in this PR (control plane)
- `docs/adr/0006-…md`: status **Proposed → Accepted** (2026-07-11); recommendation note updated to reflect acceptance.
- `patterns.md`: §1 *Content* / §5 now document the folder as `messages/` (per ADR 0006) and the per-channel file-suffix convention (`.html`, `.subject.txt`, `.inapp.txt`, `.push.subject.txt`, `.push.txt`); added a §10 changelog entry.

### Companion PR (execution)
The folder rename in the `templates` repo is **[rett-europe/templates#25](https://github.com/rett-europe/templates/pull/25)** — `git mv emails messages` (449 files, history preserved) + deploy-config path updates (`deploy-email-templates.yml`, `deploy.ps1`, README) + a new `messages/README.md`. Container name and blob paths are unchanged (prefix stripped), so `rettxapi` is unaffected and there's no blob migration. This ADR PR and #25 can merge independently — the rename doesn't alter runtime behavior.