### PR TITLE
docs(adr): 0007 — standardize AI code-review custom instructions

### DIFF
--- a/.specify/memory/patterns.md
+++ b/.specify/memory/patterns.md
@@ -299,7 +299,43 @@ issue is `cross-cutting`, it goes through gap analysis → umbrella spec →
 - Releases follow semantic versioning per repo. Cross-repo coordinated
   releases are documented in an ADR or release note here.
 
-## 10. Change log of this document
+## 10. AI-assisted code review & custom instructions
+
+We run **GitHub Copilot code review** on pull requests across the ecosystem.
+Copilot code review consumes a repo's **custom instructions**, so those files
+are how automated review is made to enforce *our* conventions. See
+[ADR 0007](../../docs/adr/0007-ai-code-review-custom-instructions.md) and the
+GitHub docs on
+[repository custom instructions](https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/add-custom-instructions/add-repository-instructions).
+
+- **Every repo maintains review-focused custom instructions.** The repo-wide
+  file `.github/copilot-instructions.md` is **mandatory** and MUST contain a
+  clearly-marked section of **enforceable review conventions** (checkable
+  statements a reviewer applies to a diff) — not a technology inventory or a
+  changelog.
+- **Two file kinds, distinct homes:**
+  - `.github/copilot-instructions.md` — repo-wide rules (applies to all files).
+  - `.github/instructions/<area>.instructions.md` — path-specific rules, each
+    with `applyTo: "<glob>"` frontmatter. **`applyTo:` is only valid in these
+    files** and is inert in the repo-wide file — never put it there.
+  - `AGENTS.md` / `CLAUDE.md` are for AI *agents*, not code review; they may
+    reference the review conventions but must not duplicate them with drift.
+- **Content rules:** keep files **concise** (long instructions get truncated);
+  prefer imperative, checkable rules; cover the repo's own non-negotiables plus
+  the cross-cutting constants every repo shares — **no PHI in code, logs, tests
+  or examples** (constitution); auth/trust boundaries (§4); full supported-
+  language set for user-facing strings (§5); API-contract ownership (§3, contracts
+  live in `rettxapi`, consumers don't fork them); and test integrity (don't
+  change source just to make a test pass). **Reference** the constitution and
+  this document rather than duplicating them.
+- **Ownership:** each repo owns its own instruction files (Copilot code review
+  reads only the target repo's files — it cannot read another repo). The control
+  plane defines the standard/skeleton and the cross-cutting text here; the
+  operative files live in each repo.
+- **Setting:** the Copilot code-review "use custom instructions" preference must
+  stay enabled (on by default).
+
+## 11. Change log of this document
 
 | Date | Change |
 |---|---|
@@ -309,4 +345,5 @@ issue is `cross-cutting`, it goes through gap analysis → umbrella spec →
 | 2026-07-07 | §1: recorded that `rettxweb` is a **Capacitor native app** (Android pilot; native FCM device tokens) in addition to the PWA, plus a *Delivery targets* note. §7: added the rule that specs must verify each fanout repo's delivery/platform mechanism against the §1 registry (and update §1 in the same PR) before `status: ready`. Prompted by spec 033 (Message Center push). |
 | 2026-07-11 | §1: registered the **`templates`** content repo as a first-class ecosystem repo (fifth kind — *Content*; deploys to the `email-templates` blob via its own CI, full sync with delete). §5: documented the **push** channel template files (`<locale>.push.subject.txt`/`.push.txt`, English fallback, generic/no-PHI) and the "missing template ⇒ channel skipped" rule. §6/§7: added the `route:templates` label, put `templates` in the fan-out allow-list, and required content-adding specs to fan a slice out to `templates`. Prompted by spec 033 push templates never being authored because `templates` was not a routable/fan-out repo — rendering shipped in `rettxapi` but the `push.*` files never existed, so push was silently skipped. |
 | 2026-07-11 | §1/§5: renamed the Message Center template folder `emails/` → **`messages/`** ([ADR 0006](../../docs/adr/0006-message-center-template-store-layout.md), Accepted) since it now carries email + in-app + push content; documented the per-channel file-suffix convention. Deploy strips the folder prefix, so the blob container stays `email-templates` and `rettxapi` is unaffected. |
+| 2026-07-11 | Added §10 **AI-assisted code review & custom instructions** ([ADR 0007](../../docs/adr/0007-ai-code-review-custom-instructions.md)): every repo must maintain a review-focused `.github/copilot-instructions.md`; path-specific rules go in `.github/instructions/*.instructions.md` with `applyTo:` frontmatter (never in the repo-wide file); files stay concise and enforce the cross-cutting non-negotiables (PHI, auth, i18n, contract ownership, test integrity). Renumbered the change log to §11. Prompted by an audit showing all repos have the file but content was uneven/agent-oriented (e.g. `rettxweb` thin, `rettxapi` with a stray `applyTo:` in the repo-wide file). |
 | 2026-07-11 | §6: retired the autonomous **Squad/Ralph** toolkit (the `squad-*.yml` workflows and `.squad/` directories) across the downstream repos. The `squad` label is **retained** as the fan-out inbox marker, now picked up by a human/orchestrated working session rather than an automated agent. See [ADR 0008](../../docs/adr/0008-retire-autonomous-squad-agent-system.md). |

--- a/docs/adr/0007-ai-code-review-custom-instructions.md
+++ b/docs/adr/0007-ai-code-review-custom-instructions.md
@@ -1,0 +1,163 @@
+# ADR 0007 — AI code-review custom instructions across the ecosystem
+
+- **Status**: Accepted (2026-07-11)
+- **Date**: 2026-07-11
+- **Decision-makers**: rettX maintainers
+- **Relates to**: [ADR 0001](0001-control-plane-repo.md) (control plane &
+  per-repo ownership), [`patterns.md` §10](../../.specify/memory/patterns.md),
+  [program constitution](../../.specify/memory/constitution.md) (PHI / privacy
+  non-negotiables), GitHub docs:
+  [Adding repository custom instructions](https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/add-custom-instructions/add-repository-instructions)
+
+## Context
+
+We use **GitHub Copilot code review** on pull requests across the ecosystem
+repos (recent examples: `rettxapi#311`, `rettxweb#181`). Copilot code review
+consumes a repo's **custom instructions** when generating a review, so those
+files are the lever for making automated review enforce *our* conventions
+rather than only generic best practice.
+
+GitHub supports three instruction types (per the docs above):
+
+- **Repository-wide** — `.github/copilot-instructions.md`. Applies to every
+  request in the repo, including code review.
+- **Path-specific** — one or more `NAME.instructions.md` files under
+  `.github/instructions/`, each with YAML frontmatter `applyTo: "<glob>"`.
+  Applied when the reviewed file matches the glob; combined with the
+  repo-wide file when both exist.
+- **Agent** — `AGENTS.md` (or a single `CLAUDE.md` / `GEMINI.md`), used by AI
+  coding agents rather than by code review.
+
+For Copilot code review, the "use custom instructions" preference must be
+enabled — it is **on by default**.
+
+An audit of the seven ecosystem repos (`rettx`, `rettxweb`, `rettxadmin`,
+`rettxapi`, `rettxmutation`, `rettxid`, `templates`) on 2026-07-11 found:
+
+- **All seven already have** `.github/copilot-instructions.md` **and**
+  `AGENTS.md`. The plumbing exists everywhere.
+- **Content is uneven and mostly agent-/onboarding-oriented, not
+  review-oriented.** Example: `rettxweb`'s file is Spec Kit auto-generated (a
+  technology inventory, "Code Style: follow standard conventions", a recent-
+  changes log) plus a large spec-drafting-mode block — almost nothing that
+  tells a *reviewer* what to flag.
+- **Where good review rules exist, they can be mis-encoded.** `rettxapi`'s file
+  carries genuinely useful, enforceable rules (repository-layer exceptions,
+  "do not modify source to make a test pass"), but it opens with
+  `applyTo: "*.py"` frontmatter — which is only meaningful in a
+  `.github/instructions/*.instructions.md` file and is inert in the repo-wide
+  file.
+- **No repo uses path-specific `.github/instructions/` files at all**, so the
+  mechanism designed for "apply these rules when reviewing files of this kind"
+  is unused.
+
+Net: automated review quality varies per repo, and our house non-negotiables
+(PHI/privacy, auth boundaries, i18n completeness, API-contract ownership, test
+integrity) are not reliably enforced by the reviewer.
+
+## Decision
+
+Adopt an ecosystem-wide standard: **every repo maintains review-focused Copilot
+custom instructions**, structured as follows.
+
+1. **Repo-wide file is mandatory and must be review-oriented.**
+   `.github/copilot-instructions.md` MUST contain a clearly-marked section of
+   **enforceable review conventions** — statements a reviewer can check a diff
+   against ("repository methods raise domain exceptions from `app.exceptions`,
+   never `HTTPException`"), not a technology inventory or a changelog. The Spec
+   Kit auto-generated block MAY remain, but the review conventions live in an
+   explicit, human-owned section.
+
+2. **Path-specific rules go in `.github/instructions/`, not the repo-wide
+   file.** Language/area-scoped rules use
+   `.github/instructions/<area>.instructions.md` with `applyTo:` frontmatter
+   (e.g. `applyTo: "**/*.py"`). `applyTo:` MUST NOT appear in
+   `copilot-instructions.md` (it is inert there) — fixing `rettxapi`'s current
+   mis-placement is part of rollout.
+
+3. **Content rules.** Keep files **concise** (long instructions get truncated
+   and diluted). Prefer imperative, checkable rules. Cover the repo's own
+   non-negotiables **plus** the cross-cutting constants every repo shares:
+   **no PHI in code, logs, tests, or examples** (constitution); auth/trust
+   boundaries; full supported-language set for user-facing strings
+   (`patterns.md` §5); API-contract ownership (contracts live in `rettxapi`,
+   consumers don't fork them — `patterns.md` §3); and test integrity (don't
+   change source just to make a test pass). **Reference** the repo constitution
+   and control-plane `patterns.md` rather than duplicating them, so there is a
+   single source of truth.
+
+4. **No divergence between instruction files.** Review conventions have one
+   canonical home per repo (the repo-wide file and/or `.github/instructions/`).
+   `AGENTS.md`/`CLAUDE.md` may point at it, but the same rule must not be
+   maintained in two places with drift.
+
+5. **Keep the setting on.** The "use custom instructions for Copilot code
+   review" preference stays enabled (default). Rollout verifies this per repo/
+   org.
+
+This ADR sets the **standard and the control-plane template**; it does not by
+itself rewrite the six downstream files — that is a fan-out (see Follow-ups),
+executed per repo since each repo owns its own conventions and Copilot reads
+each repo's files independently.
+
+## Options considered
+
+- **Option A — repo-wide file only (baseline).** A single strong
+  `copilot-instructions.md` per repo. Simplest; sufficient for small/uniform
+  repos.
+- **Option B — repo-wide + path-specific (recommended target).** Repo-wide file
+  for cross-file rules, plus `.github/instructions/*.instructions.md` where a
+  repo has clear language/area splits (e.g. `rettxapi` Python rules, a web
+  repo's `*.spec.ts` test rules). Best signal-to-noise for review.
+- **Option C — centralize all conventions in the control plane.** Rejected:
+  Copilot code review reads the **target repo's** files only; it cannot read
+  another repo. Per-repo files are structurally required, so the control plane
+  can define the standard and cross-cutting text but cannot host the operative
+  files for other repos.
+
+## Recommendation
+
+Adopt **Option A as the floor everywhere** and **Option B where a repo has a
+natural area split**. Concretely:
+
+- Control plane publishes a short **skeleton** (`copilot-instructions.md`
+  section headings + a starter set of cross-cutting rules) and records the
+  standard in `patterns.md` §10.
+- Each repo's file gains a **"Conventions Copilot must enforce in review"**
+  section seeded from its constitution + `patterns.md`.
+- `rettxapi` moves its `*.py` rules into
+  `.github/instructions/python.instructions.md` (correct `applyTo:` home) and
+  keeps cross-file rules in the repo-wide file.
+- `rettxweb` gains real review conventions beyond the auto-generated tech list.
+
+## Consequences
+
+### Positive
+- Automated review enforces house conventions (PHI, layering, contracts, i18n,
+  test integrity), not just generic advice — consistently across repos.
+- The `applyTo:` mechanism is used correctly, so path-scoped rules actually fire.
+- One canonical home per rule reduces drift between agent and review guidance.
+
+### Negative / cost
+- Six downstream files to author/upgrade and then keep current as conventions
+  evolve (bounded; each is small).
+- Over-long or stale instructions can *hurt* review quality, so files must stay
+  concise and be maintained.
+
+### Neutral
+- No change to runtime code or CI. Existing `AGENTS.md`/`CLAUDE.md` files stay;
+  they are only cross-referenced, not deleted.
+
+## Follow-ups (on acceptance)
+
+- **Control plane (this PR)** — record the standard in `patterns.md` §10 and
+  link this ADR. Optionally add a starter skeleton under `.specify/templates/`.
+- **Fan-out (gated on maintainer go-ahead)** — a slice per downstream repo
+  (`rettxweb`, `rettxapi`, `rettxadmin`, `rettxmutation`, `rettxid`,
+  `templates`) to add/upgrade the review-focused section, and to introduce
+  `.github/instructions/*.instructions.md` where Option B applies. Track under
+  the cross-cutting routing process (`route:*` / `squad`).
+- **`rettxapi`** — move the stray `applyTo: "*.py"` block from
+  `copilot-instructions.md` into `.github/instructions/python.instructions.md`.
+- **Settings** — confirm the Copilot code-review custom-instructions preference
+  is enabled at the org/repo level.


### PR DESCRIPTION
## Summary

Establishes an ecosystem-wide standard so **GitHub Copilot code review** enforces our house conventions, not just generic best practice. Control-plane artifacts only (ADR + `patterns.md`); per-repo rollout is a **gated follow-up**.

Prompted by the review comments on `rettxapi#311` / `rettxweb#181` and a quick audit of all seven repos.

## What's here
- **New `docs/adr/0007-ai-code-review-custom-instructions.md`** (Accepted):
  - Every repo maintains a **review-focused** `.github/copilot-instructions.md` (enforceable, checkable rules — not a tech inventory).
  - Path-specific rules go in `.github/instructions/<area>.instructions.md` with `applyTo:` frontmatter; **`applyTo:` is inert in the repo-wide file** — never put it there.
  - Files stay concise and enforce the cross-cutting non-negotiables: **no PHI** (constitution), auth boundaries (§4), full i18n set (§5), **API-contract ownership** (§3), and test integrity ("don't change source to make a test pass").
  - Each repo owns its files (Copilot review only reads the target repo); the control plane defines the standard.
- **`patterns.md`**: new **§10 — AI-assisted code review & custom instructions**; change log renumbered to **§11** with an entry.

## Audit findings that motivated this
- All 7 repos already have `.github/copilot-instructions.md` + `AGENTS.md` — but content is **uneven and agent-oriented**.
- `rettxweb`'s file is thin (Spec Kit auto-gen tech list + "follow standard conventions").
- `rettxapi`'s file has good rules but opens with a stray `applyTo: "*.py"` (invalid in the repo-wide file).
- **No** repo uses path-specific `.github/instructions/` files.

## Not in this PR (follow-ups, per ADR)
- Fan-out slice per downstream repo to author/upgrade the review section (gated on maintainer go-ahead).
- Move `rettxapi`'s `*.py` rules into `.github/instructions/python.instructions.md`.
- Confirm the org/repo "use custom instructions for code review" setting is enabled (default on).