### PR TITLE
docs(adr): 0008 — retire the autonomous Squad/Ralph agent system

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -45,7 +45,8 @@ this repo's context**. Instead:
 1. Capture the change in a cross-cutting spec under `specs/`.
 2. Once merged, the `spec-fanout` workflow opens scoped issues in the
    affected repos (label: `squad`).
-3. Each downstream repo's own agents / squad pick up the work there.
+3. A maintainer picks up each fan-out issue by spawning an orchestrated
+   working session in that repo (one session → one branch → one PR).
 
 ## Style
 

--- a/.github/workflows/spec-fanout.yml
+++ b/.github/workflows/spec-fanout.yml
@@ -222,7 +222,7 @@ jobs:
               gh label create squad \
                 --repo "rett-europe/${target}" \
                 --color 9B8FCC \
-                --description "Squad triage inbox — Lead will assign to a member" \
+                --description "Fan-out inbox — pick up via an orchestrated session" \
                 --force >/dev/null 2>&1 || true
 
               url=$(gh issue create \

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -245,8 +245,8 @@ elaborated and kept current in [`patterns.md`](./patterns.md).
 - **Issue routing labels** (set by Iris): `route:web`, `route:admin`,
   `route:api`, `route:mutation`, `route:id`, `cross-cutting`, plus state
   labels `needs-triage`, `triaged`, `routed`. Downstream issues created
-  by the fanout carry the label `squad` so each repo's automation can
-  pick them up.
+  by the fanout carry the label `squad` so a maintainer can pick them up
+  by spawning an orchestrated working session in that repo.
 - **Identity attribution**: automated actions across the ecosystem repos
   run under the `rettx-iris[bot]` GitHub App identity. Human actions run
   as the human's own account.

--- a/.specify/memory/patterns.md
+++ b/.specify/memory/patterns.md
@@ -214,10 +214,13 @@ form the contract between intake and execution.
 | `bug` | Defect report | Issue template |
 | `spec-proposal` | New idea / feature proposal | Issue template |
 | `question` | Public question | Issue template |
-| `squad` | (downstream repos) Pick this up via the local Squad team | Iris fanout |
+| `squad` | (downstream repos) Fan-out inbox — a maintainer picks this up by spawning an orchestrated working session | Iris fanout |
 
-In downstream repos, the `squad` label is the trigger for that repo's
-local Squad/Copilot agent to begin work.
+In downstream repos, the `squad` label marks a fan-out **inbox** issue: a
+maintainer picks it up by spawning an orchestrated working session
+(one session → one branch → one PR). It no longer triggers any
+automated local agent or "squad" team — the autonomous Squad/Ralph
+toolkit was retired (see [ADR 0008](../../docs/adr/0008-retire-autonomous-squad-agent-system.md)).
 
 **Cross-cutting issues do not use the raw `/route confirm` fan-out.** The
 `route:*` + `/route confirm` path (`iris-route`) copies the issue text into a
@@ -306,3 +309,4 @@ issue is `cross-cutting`, it goes through gap analysis → umbrella spec →
 | 2026-07-07 | §1: recorded that `rettxweb` is a **Capacitor native app** (Android pilot; native FCM device tokens) in addition to the PWA, plus a *Delivery targets* note. §7: added the rule that specs must verify each fanout repo's delivery/platform mechanism against the §1 registry (and update §1 in the same PR) before `status: ready`. Prompted by spec 033 (Message Center push). |
 | 2026-07-11 | §1: registered the **`templates`** content repo as a first-class ecosystem repo (fifth kind — *Content*; deploys to the `email-templates` blob via its own CI, full sync with delete). §5: documented the **push** channel template files (`<locale>.push.subject.txt`/`.push.txt`, English fallback, generic/no-PHI) and the "missing template ⇒ channel skipped" rule. §6/§7: added the `route:templates` label, put `templates` in the fan-out allow-list, and required content-adding specs to fan a slice out to `templates`. Prompted by spec 033 push templates never being authored because `templates` was not a routable/fan-out repo — rendering shipped in `rettxapi` but the `push.*` files never existed, so push was silently skipped. |
 | 2026-07-11 | §1/§5: renamed the Message Center template folder `emails/` → **`messages/`** ([ADR 0006](../../docs/adr/0006-message-center-template-store-layout.md), Accepted) since it now carries email + in-app + push content; documented the per-channel file-suffix convention. Deploy strips the folder prefix, so the blob container stays `email-templates` and `rettxapi` is unaffected. |
+| 2026-07-11 | §6: retired the autonomous **Squad/Ralph** toolkit (the `squad-*.yml` workflows and `.squad/` directories) across the downstream repos. The `squad` label is **retained** as the fan-out inbox marker, now picked up by a human/orchestrated working session rather than an automated agent. See [ADR 0008](../../docs/adr/0008-retire-autonomous-squad-agent-system.md). |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,9 +70,10 @@ The flow is:
    downstream repo that needs to act, each with a per-repo `summary:`.
 4. On merge to `main`, the `Iris — spec fanout` workflow reads the
    frontmatter and opens a `[spec/<slug>] <title>` issue with the
-   `squad` label in each fanout target. Each downstream squad then
-   runs its own `/speckit.plan` and `/speckit.tasks` against the spec
-   link in their repo and executes the work.
+   `squad` label in each fanout target. A maintainer then picks up each
+   fan-out issue by spawning an orchestrated working session in that
+   downstream repo, running its own `/speckit.plan` and `/speckit.tasks`
+   against the spec link and executing the work.
 
 Please do not start writing code in a downstream repository for a
 cross-cutting change before the spec here is at least at "Draft —
@@ -88,7 +89,7 @@ of the flow runs here. Implementation happens in the downstream repos.
 |---|---|---|
 | `/speckit.constitution` | ✅ | Program constitution lives at `.specify/memory/constitution.md` |
 | `/speckit.specify` | ✅ | Drafts a new program-level spec into `specs/<NNNN>-<slug>/spec.md` from `.specify/templates/spec-template.md`, including the `fanout:` frontmatter block. |
-| `/speckit.plan`, `/speckit.tasks`, `/speckit.implement` | ❌ | Implementation happens in the downstream repos. Iris fans the merged spec out as squad issues; each downstream squad runs `/speckit.plan` and `/speckit.tasks` against the spec link in their repo. |
+| `/speckit.plan`, `/speckit.tasks`, `/speckit.implement` | ❌ | Implementation happens in the downstream repos. Iris fans the merged spec out as `[spec/<slug>]` issues (label `squad`); a maintainer picks each one up by spawning an orchestrated working session that runs `/speckit.plan` and `/speckit.tasks` against the spec link in that repo. |
 
 If you want to author a spec from your editor, open this repo in an
 editor that supports GitHub Copilot slash commands, and run

--- a/docs/adr/0008-retire-autonomous-squad-agent-system.md
+++ b/docs/adr/0008-retire-autonomous-squad-agent-system.md
@@ -1,0 +1,89 @@
+# ADR 0008 — Retire the autonomous Squad/Ralph agent system
+
+- **Status**: Accepted (2026-07-11)
+- **Date**: 2026-07-11
+- **Decision-makers**: rettX maintainers
+- **Relates to**: [ADR 0002](0002-cross-cutting-gap-analysis-pipeline.md)
+  (gap-analysis → umbrella spec → `spec-fanout` orchestration pipeline),
+  [`patterns.md` §6](../../.specify/memory/patterns.md) (issue routing labels)
+
+## Context
+
+Each downstream execution repo (`rettxapi`, `rettxweb`, `rettxadmin`) shipped a
+self-contained **Squad** toolkit — colloquially "Ralph" — that let a set of
+autonomous agents act on issues without a human in the loop. It consisted of:
+
+- Four GitHub Actions workflows: `squad-heartbeat.yml`, `squad-issue-assign.yml`,
+  `squad-triage.yml`, and `sync-squad-labels.yml`.
+- A `.squad/` directory holding Star-Wars-named agent **charters**, **ceremonies**,
+  **routing** rules, and **config** that told those agents how to self-assign,
+  triage, and begin work.
+
+The system watched for issues labelled `squad` (the fan-out inbox label applied by
+the control-plane `spec-fanout` workflow) and would auto-assign, triage, and start
+work on them. Its heartbeat and triage jobs ran on **every PR and push**, producing
+a steady stream of CI noise and bot chatter that was disproportionate to the value
+it delivered. In practice the autonomous behaviour was hard to reason about: two
+overlapping coordination models (autonomous Squad vs. human orchestration) existed
+side by side, and the Squad path frequently acted on issues in ways a maintainer
+then had to correct.
+
+Meanwhile the program adopted a **session-based orchestration** model. Under
+[ADR 0002](0002-cross-cutting-gap-analysis-pipeline.md), cross-cutting work is
+gap-analysed and specced in the control plane, then fanned out; a human coordinator
+opens the resulting issues/specs and **spawns one working session per repo**, each
+landing its own PR. That model already covers everything the Squad system was meant
+to do — and does it with a clear, auditable, one-session-one-branch-one-PR shape —
+so the autonomous layer became redundant overhead.
+
+## Decision
+
+**Retire the autonomous Squad/Ralph system.**
+
+- **Delete** the four `squad-*.yml` workflows (`squad-heartbeat.yml`,
+  `squad-issue-assign.yml`, `squad-triage.yml`, `sync-squad-labels.yml`) and the
+  `.squad/` directory from every downstream repo that carried them.
+- **Keep the `squad` GitHub label.** It is unchanged as a routing artifact: the
+  control-plane `spec-fanout` workflow still applies it to each `[spec/<slug>]`
+  downstream issue. What changes is that the label **no longer triggers any
+  automation**. It is now purely the **fan-out inbox** marker — a human/orchestrated
+  working session picks the issue up rather than an autonomous agent.
+- **Retain the spec-kit workflows.** The control-plane pipeline
+  (`issue-to-spec` / `spec-to-branch` / `spec-pr-guard`, and the `spec-fanout`
+  fan-out itself) is unaffected. Downstream repos keep their local spec-kit
+  commands; only the autonomous Squad layer on top of them is removed.
+
+### Scope
+
+Repos cleaned up by this decision:
+
+- `rettxapi`
+- `rettxweb`
+- `rettxadmin`
+
+`rettxid`, `rettxmutation`, and `templates` never carried the Squad toolkit, so
+there is nothing to remove there.
+
+Implementation PRs: <to be linked>
+
+## Consequences
+
+### Positive
+
+- **Less CI noise.** The heartbeat/triage jobs no longer run on every PR and push.
+- **One coordination model.** Session-based orchestration (ADR 0002) is now the
+  single way cross-cutting work is picked up and executed — no competing autonomous
+  path.
+- **Simpler mental model.** A maintainer reads a `squad`-labelled issue as an inbox
+  item to pick up, not as something a bot may already be acting on.
+
+### Negative / neutral
+
+- **No more auto-assignment or auto-triage** in the downstream repos; a human must
+  now spawn a session to act on a `squad` issue.
+- The `squad:<member>` **sub-labels become orphaned metadata** — they no longer map
+  to any active agent. They can be pruned opportunistically; leaving them in place
+  is harmless.
+- Downstream `squad` issues now **require a human/orchestrated session** to move
+  forward. This is intentional: the pickup is deliberate and auditable rather than
+  automatic.

--- a/docs/adr/0008-retire-autonomous-squad-agent-system.md
+++ b/docs/adr/0008-retire-autonomous-squad-agent-system.md
@@ -42,7 +42,10 @@ so the autonomous layer became redundant overhead.
 
 - **Delete** the four `squad-*.yml` workflows (`squad-heartbeat.yml`,
   `squad-issue-assign.yml`, `squad-triage.yml`, `sync-squad-labels.yml`) and the
-  `.squad/` directory from every downstream repo that carried them.
+  `.squad/` directory from every downstream repo that carried them. The removal
+  also sweeps up the **companion artifacts** the toolkit installed: the Squad
+  **Coordinator** agent (`.github/agents/squad.agent.md`) and, in `rettxweb` and
+  `rettxadmin`, the six Squad-coupled Copilot skills under `.copilot/skills/`.
 - **Keep the `squad` GitHub label.** It is unchanged as a routing artifact: the
   control-plane `spec-fanout` workflow still applies it to each `[spec/<slug>]`
   downstream issue. What changes is that the label **no longer triggers any
@@ -64,7 +67,11 @@ Repos cleaned up by this decision:
 `rettxid`, `rettxmutation`, and `templates` never carried the Squad toolkit, so
 there is nothing to remove there.
 
-Implementation PRs: <to be linked>
+Implementation PRs:
+
+- `rettxapi` — [rett-europe/rettxapi#312](https://github.com/rett-europe/rettxapi/pull/312)
+- `rettxweb` — [rett-europe/rettxweb#182](https://github.com/rett-europe/rettxweb/pull/182)
+- `rettxadmin` — [rett-europe/rettxadmin#55](https://github.com/rett-europe/rettxadmin/pull/55)
 
 ## Consequences
 


### PR DESCRIPTION
## Summary

Records the retirement of the autonomous **Squad/Ralph** agent system and reconciles the docs that still described it as live automation.

### New ADR
- **`docs/adr/0008-retire-autonomous-squad-agent-system.md`** (Status: Accepted, 2026-07-11). Documents:
  - **Context** — what the Squad/Ralph toolkit was (the four `squad-*.yml` workflows + `.squad/` charter/ceremony/routing/config dirs in downstream repos), that its heartbeat/triage ran on every PR/push and produced noise, and that the program moved to the session-based orchestration model (ref [ADR 0002](docs/adr/0002-cross-cutting-gap-analysis-pipeline.md)).
  - **Decision** — delete the four `squad-*.yml` workflows and `.squad/` dirs from downstream repos; **keep the `squad` label** purely as the `spec-fanout` inbox marker, now picked up by a human/orchestrated session; **retain** the spec-kit workflows (`issue-to-spec`/`spec-to-branch`/`spec-pr-guard`, and `spec-fanout` itself).
  - **Scope** — cleaned up in `rettxapi`, `rettxweb`, `rettxadmin`; `rettxid`/`rettxmutation`/`templates` never had it.
  - **Consequences** — less CI noise, one coordination model, simpler mental model; no more auto-assign/triage, `squad:<member>` sub-labels become orphaned metadata, downstream `squad` issues now need a human to spawn a session.
  - Includes an `Implementation PRs: <to be linked>` placeholder for the three downstream removal PRs.

### Doc reconciliations
- **`.specify/memory/patterns.md`** §6 — reworded the `squad` label row + note to describe the current reality (fan-out inbox picked up by an orchestrated session, no automated local team). Added a §10 change-log entry dated 2026-07-11.
- **`.specify/memory/constitution.md`** — reworded the factual description of the `squad` label pickup mechanism (human/orchestrated, not "each repo's automation"). No numbered NON-NEGOTIABLE principle touched.
- **`CONTRIBUTING.md`** — replaced "each downstream squad" / "the downstream squad runs…" phrasing (steps 4 and the spec-kit table) with maintainer/orchestrated-session language.
- **`.github/copilot-instructions.md`** — "Each downstream repo's own agents / squad pick up the work there" → orchestrated-session pickup.
- **`.github/workflows/spec-fanout.yml`** — one-line label **description** string only ("Squad triage inbox…" → "Fan-out inbox — pick up via an orchestrated session"). No workflow logic changed; the fan-out still applies the `squad` label.

### Intentionally left as-is
Purely factual "the issue carries the `squad` label" / "squad issue" naming in `docs/adr/0002`, `site/src/content/docs/specs/index.md`, `.specify/templates/spec-template.md`, and the `specs/03x` specs — the label and fan-out issue name are unchanged. Historical mentions in `docs/adr/0001` and `specs/001-security-deep-dive/` are point-in-time records left untouched.

### Note
The three downstream removal PRs (rettxapi, rettxweb, rettxadmin) are **separate** and will be cross-linked into the ADR's `Implementation PRs` line once their numbers are available.