### PR TITLE
spec(037): flip status ready — arm menstrual duration fanout

### DIFF
--- a/specs/037-pulse-menstrual-duration/spec.md
+++ b/specs/037-pulse-menstrual-duration/spec.md
@@ -17,7 +17,7 @@
 spec_id: "037"
 slug: "pulse-menstrual-duration"
 title: "rettX Pulse — Menstrual Period as Start + Duration"
-status: draft   # draft | ready | accepted | superseded
+status: ready   # draft | ready | accepted | superseded
 authored: "2026-07-22"
 author: "perocha"
 source_issue: "rett-europe/rettxweb#231"


### PR DESCRIPTION
One-line status flip (draft → ready) for the already-merged spec 037 (menstrual start+duration, #35). On merge, spec-fanout opens the scoped squad issues in rettxapi (contract owner, land first) and rettxweb. No content changes.