### PR TITLE
spec(038): flip status ready to trigger sleep fanout

### DIFF
--- a/specs/038-pulse-sleep-tracking/spec.md
+++ b/specs/038-pulse-sleep-tracking/spec.md
@@ -19,7 +19,7 @@
 spec_id: "038"
 slug: "pulse-sleep-tracking"
 title: "rettX Pulse — Sleep Tracking"
-status: draft   # draft | ready | accepted | superseded
+status: ready   # draft | ready | accepted | superseded
 authored: "2026-07-22"
 author: "perocha"
 source_issue: "product-request (Pedro, 2026-07-22)"


### PR DESCRIPTION
Flips spec 038 (pulse-sleep-tracking) status draft -> ready so the spec-fanout workflow opens the rettxapi + rettxweb squad issues on merge. Spec content already reviewed and merged via #37.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>