### PR TITLE
docs(site): publish all ADRs to the docs site

### DIFF
--- a/scripts/sync-adrs.mjs
+++ b/scripts/sync-adrs.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+// Build-time sync: publish every ADR in docs/adr/ as a Starlight page under
+// site/src/content/docs/decisions/, and regenerate the decisions index table.
+//
+// docs/adr/ is the single source of truth. The site pages are a generated view.
+// Pure Node ESM, no external dependencies (node:fs + node:path only). Idempotent:
+// re-running yields byte-identical output.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+const adrDir = path.join(root, 'docs', 'adr');
+const outDir = path.join(root, 'site', 'src', 'content', 'docs', 'decisions');
+const indexPath = path.join(outDir, 'index.md');
+
+const REPO_BLOB_BASE = 'https://github.com/rett-europe/rettx/blob/main/';
+
+/** Quote a string as a safe double-quoted YAML scalar. */
+function yamlQuote(value) {
+  return '"' + String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"';
+}
+
+/** Strip backtick characters. */
+function stripBackticks(value) {
+  return value.replace(/`/g, '');
+}
+
+/**
+ * Rewrite a relative markdown link target (relative to docs/adr/) into an
+ * absolute GitHub blob URL. Absolute, anchor-only, and mailto links are left
+ * untouched. A trailing #anchor on a relative link is preserved.
+ */
+function rewriteTarget(target) {
+  if (/^(https?:\/\/|#|mailto:)/.test(target)) {
+    return target;
+  }
+  const hashIndex = target.indexOf('#');
+  const pathPart = hashIndex === -1 ? target : target.slice(0, hashIndex);
+  const anchor = hashIndex === -1 ? '' : target.slice(hashIndex);
+  const resolved = path.posix.normalize('docs/adr/' + pathPart);
+  return REPO_BLOB_BASE + resolved + anchor;
+}
+
+/** Rewrite all relative markdown links in a body of text. */
+function rewriteLinks(body) {
+  return body.replace(/\]\(([^)]+)\)/g, (match, target) => {
+    return '](' + rewriteTarget(target) + ')';
+  });
+}
+
+function readAdrs() {
+  const files = fs
+    .readdirSync(adrDir)
+    .filter((name) => name.toLowerCase().endsWith('.md'))
+    .sort();
+
+  return files.map((filename) => {
+    const source = fs.readFileSync(path.join(adrDir, filename), 'utf8').replace(/\r\n/g, '\n');
+    const lines = source.split('\n');
+
+    // First line is the H1 title.
+    const firstLine = lines[0] ?? '';
+    const title = stripBackticks(firstLine.replace(/^#\s+/, '')).trim();
+
+    // Description = text after the em dash in the title; else the whole title.
+    const dashIndex = title.indexOf('—');
+    const description =
+      dashIndex === -1 ? title : title.slice(dashIndex + 1).trim();
+
+    // Decision text = title without the leading "ADR NNNN — " prefix.
+    const decision = title.replace(/^ADR\s+\d+\s*—\s*/, '').trim();
+
+    // ADR number from the 4-digit filename prefix.
+    const numMatch = filename.match(/^(\d{4})/);
+    const adrNumber = numMatch ? parseInt(numMatch[1], 10) : 0;
+    const numLabel = numMatch ? numMatch[1] : String(adrNumber);
+
+    // Status from the "- **Status**: ..." line.
+    let status = 'Accepted';
+    for (const line of lines) {
+      const m = line.match(/^- \*\*Status\*\*:\s*(.+)$/);
+      if (m) {
+        status = m[1].trim();
+        break;
+      }
+    }
+
+    // Body = source with the first H1 removed and leading blank lines trimmed.
+    let body = lines.slice(1).join('\n').replace(/^\n+/, '');
+    body = rewriteLinks(body);
+
+    const slug = filename.replace(/\.md$/i, '');
+
+    return { filename, slug, title, description, decision, adrNumber, numLabel, status, body };
+  });
+}
+
+function writePage(adr) {
+  const frontmatter =
+    '---\n' +
+    'title: ' + yamlQuote(adr.title) + '\n' +
+    'description: ' + yamlQuote(adr.description) + '\n' +
+    'sidebar:\n' +
+    '  order: ' + (adr.adrNumber + 1) + '\n' +
+    '---\n';
+
+  const content = frontmatter + '\n' + adr.body;
+  fs.writeFileSync(path.join(outDir, adr.filename), content);
+}
+
+function regenerateIndex(adrs) {
+  const heading = '## Currently merged ADRs';
+  const original = fs.readFileSync(indexPath, 'utf8').replace(/\r\n/g, '\n');
+  const headingIndex = original.indexOf(heading);
+
+  const preamble =
+    headingIndex === -1 ? original.replace(/\s*$/, '') + '\n\n' : original.slice(0, headingIndex);
+
+  const sorted = [...adrs].sort((a, b) => a.adrNumber - b.adrNumber);
+
+  const rows = sorted.map((adr) => {
+    const numCell = `[${adr.numLabel}](/decisions/${adr.slug}/)`;
+    const titleCell = stripBackticks(adr.decision);
+    return `| ${numCell} | ${titleCell} | ${adr.status} |`;
+  });
+
+  const section =
+    heading + '\n\n' + '| # | Title | Status |\n' + '|---|---|---|\n' + rows.join('\n') + '\n';
+
+  fs.writeFileSync(indexPath, preamble + section);
+}
+
+function main() {
+  fs.mkdirSync(outDir, { recursive: true });
+  const adrs = readAdrs();
+  for (const adr of adrs) {
+    writePage(adr);
+  }
+  regenerateIndex(adrs);
+  console.log(`Synced ${adrs.length} ADRs to site/src/content/docs/decisions/`);
+}
+
+main();

--- a/site/package.json
+++ b/site/package.json
@@ -5,9 +5,10 @@
   "type": "module",
   "description": "rettX engineering documentation site (docs.rettx.eu) — Astro + Starlight.",
   "scripts": {
-    "dev": "astro dev",
+    "dev": "node ../scripts/sync-adrs.mjs && astro dev",
     "start": "astro dev",
-    "build": "astro check && astro build",
+    "sync:adrs": "node ../scripts/sync-adrs.mjs",
+    "build": "node ../scripts/sync-adrs.mjs && astro check && astro build",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/site/src/content/docs/decisions/0001-control-plane-repo.md
+++ b/site/src/content/docs/decisions/0001-control-plane-repo.md
@@ -1,0 +1,202 @@
+---
+title: "ADR 0001 — rettx is the rettX control-plane repo"
+description: "rettx is the rettX control-plane repo"
+sidebar:
+  order: 2
+---
+
+- **Status**: Accepted
+- **Date**: 2026-05-01
+- **Decision-makers**: rettX maintainers
+
+## Context
+
+The rettX ecosystem comprises:
+
+- **Surfaces (deployed user-facing apps)**
+  - [`rettxweb`](https://github.com/rett-europe/rettxweb) — caregiver PWA
+  - [`rettxadmin`](https://github.com/rett-europe/rettxadmin) — admin dashboard
+- **Backend (deployed service)**
+  - [`rettxapi`](https://github.com/rett-europe/rettxapi)
+- **Libraries (Python packages consumed by the backend, released to PyPI)**
+  - [`rettxmutation`](https://github.com/rett-europe/rettxmutation) — agentic mutation extraction & HGVS validation
+  - [`rettxid`](https://github.com/rett-europe/rettxid) — pseudonymous rettX ID format
+
+The surfaces and backend each have their own technical constitution
+(`.specify/memory/constitution.md`) and Squad / spec-kit setup.
+The libraries follow stricter semantic versioning, are released
+independently to PyPI, and are pinned by `rettxapi` via `requirements.in`.
+
+Until now there was no shared place for:
+
+- the program-level constitution (mission, GDPR posture, transparency,
+  accessibility, cross-repo conventions);
+- cross-cutting specifications that touch more than one ecosystem repo;
+- a public-facing documentation site explaining the registry to families,
+  clinicians, and partners;
+- a single intake point for issues, with consistent triage and routing
+  to the right execution repo.
+
+The result was that high-level decisions risked being lost in commit
+history, public visibility relied on individual repo READMEs, and
+coordinating a change across repos required manual copy-paste of issues
+and specs.
+
+## Decision
+
+The `rettx` repository becomes the **public control plane** for the rettX
+solution. It contains:
+
+- `.specify/memory/constitution.md` — program-level constitution.
+- `.specify/memory/patterns.md` — cross-repository conventions.
+- `specs/` — cross-cutting specifications authored using the spec-kit
+  workflow.
+- `docs/adr/` — program-level ADRs (this is one of them).
+- `site/` — source for the public documentation site.
+- `.github/ISSUE_TEMPLATE/` — public intake forms.
+- `.github/workflows/` — Iris (intake/triage), spec fanout, and docs
+  deployment automation.
+
+The repository is **public**, consistent with the program constitution's
+transparency principle.
+
+The surface, backend, and library repos retain full ownership of their
+technical constitutions, code, tests, and CI. They link back to the
+program constitution but are not subordinated technically. Library
+releases continue to flow through PyPI and are pinned by `rettxapi`.
+
+### Spec & issue flow
+
+> **Amended by [ADR 0002](https://github.com/rett-europe/rettx/blob/main/docs/adr/0002-cross-cutting-gap-analysis-pipeline.md)**: the
+> `/route confirm` fan-out below is now reserved for **single-repo** work.
+> Cross-cutting issues go through gap analysis → umbrella spec → `spec-fanout`
+> instead of a raw fan-out.
+
+```
+issue opened here
+        │
+        ▼
+   Iris classifies → labels (route:*) → posts recommendation
+        │
+        ▼
+   maintainer comments /route confirm
+        │
+        ▼
+   Iris opens linked issues in target repos (label: squad)
+        │
+        ▼
+   per-repo Squad / Copilot picks up, runs spec-kit plan/tasks/implement
+```
+
+For cross-cutting specifications:
+
+```
+spec authored in rettx/specs/NNNN-slug/  (spec.md, plan.md, tasks.md)
+        │
+        ▼
+   spec PR merges to main
+        │
+        ▼
+   spec-fanout workflow opens one issue per target repo (label: squad)
+        │
+        ▼
+   per-repo execution as above
+```
+
+### Cross-repo automation identity
+
+All cross-repo automation runs under a dedicated GitHub App,
+**`rettx-iris`**, installed on the `rett-europe` org with `Issues: R/W`,
+`Pull requests: R/W`, `Contents: R`, `Metadata: R`. Tokens are minted
+per-run via `actions/create-github-app-token`, so no long-lived
+credentials are stored. All bot actions are publicly attributable to
+`rettx-iris[bot]`.
+
+### Permission model
+
+- Anyone with a GitHub account can open issues using the templates.
+- Iris (bot) classifies and comments only; it does not open downstream
+  issues unilaterally.
+- Routing is committed only when a user with `write` permission or
+  higher on `rettx` comments `/route confirm`. The Action verifies this
+  via `getCollaboratorPermissionLevel` before acting.
+
+### Public documentation site
+
+The patient-facing landing for rettX is the existing WordPress site at
+**rettx.eu** (and the caregiver app at `app.rettx.eu`). This control
+plane is *not* a replacement for that landing.
+
+The site delivered by this repository is an **engineering and
+governance** surface, aimed at contributors, clinical partners, and
+community members who want to inspect how rettX is built and operated.
+It is published at **`docs.rettx.eu`**. The site source lives in
+`site/` and is built with **Astro Starlight**, deployed to **GitHub
+Pages** via Actions from the `main` branch (no `gh-pages` branch). DNS
+is configured as a CNAME from `docs.rettx.eu` to the GitHub Pages
+target; the `CNAME` file in the deployed site enforces the custom
+domain.
+
+## Alternatives considered
+
+### A. Adopt Squad in the control plane
+
+Rejected. Squad is optimised for repos that contain code being executed
+on. The control plane is markdown + automation; a persistent
+multi-agent team would produce ceremony without commensurate value.
+Squad continues to be used in each downstream execution repo.
+
+### B. Use a hosted issue-tracker (Linear, Jira) as the control plane
+
+Rejected. The transparency principle requires the planning surface to be
+public. Hosted issue trackers add friction for community contribution
+and obscure the audit trail.
+
+### C. Keep specs in each repo and only host docs here
+
+Rejected for cross-cutting specs. When a single change spans repos, a
+single source of truth simplifies coordination and review. Single-repo
+work continues to be specced in its home repo.
+
+### D. Skip Iris; rely on manual triage
+
+Rejected as the long-term answer. Manual triage does not scale and
+loses the holistic view across repos that is the central value of this
+control plane. A lean automated triage with a human gate gives both
+scalability and accountability.
+
+## Consequences
+
+### Positive
+
+- Single, public source of truth for program-level decisions.
+- One place for the community to ask questions and propose changes.
+- Cross-repo work has a coherent home.
+- Public docs site backed by the same review/PR workflow as everything
+  else.
+- All automated cross-repo actions are publicly attributable.
+
+### Negative
+
+- Additional repository to maintain.
+- Contributors must understand the two-layer constitution model
+  (program-level here, technical per-repo).
+- Cross-cutting specs require fanout discipline; if `tasks.md` is not
+  cleanly grouped per-repo, fanout cannot work correctly.
+
+### Neutral
+
+- The execution repos continue to function autonomously; they receive
+  scoped work via labelled issues and otherwise operate as today.
+
+## Follow-ups
+
+- Add a back-link from each downstream repo's
+  `.specify/memory/constitution.md` to this program constitution.
+- Reconcile the i18n language-code divergence noted in `patterns.md`.
+- Wire DNS for `docs.rettx.eu` to GitHub Pages (CNAME) when the site is
+  ready to publish.
+- Revisit visibility of `rettxweb` / `rettxadmin` / `rettxapi` periodically
+  per program constitution Principle VII.
+- Evaluate whether to publish a weekly cross-repo digest as an issue
+  here.

--- a/site/src/content/docs/decisions/0002-cross-cutting-gap-analysis-pipeline.md
+++ b/site/src/content/docs/decisions/0002-cross-cutting-gap-analysis-pipeline.md
@@ -1,0 +1,153 @@
+---
+title: "ADR 0002 — Gap-analysis-first pipeline for cross-cutting work"
+description: "Gap-analysis-first pipeline for cross-cutting work"
+sidebar:
+  order: 3
+---
+
+- **Status**: Accepted
+- **Date**: 2026-06-22
+- **Decision-makers**: rettX maintainers
+- **Amends**: [ADR 0001](https://github.com/rett-europe/rettx/blob/main/docs/adr/0001-control-plane-repo.md) (the *cross-cutting* portion of
+  its "Spec & issue flow"; single-repo routing is unchanged)
+
+## Context
+
+ADR 0001 established `rettx` as the control plane and defined two flows: a
+`/route confirm` fan-out (Iris copies the raw issue body into sub-issues in the
+target repos) and a `spec-fanout` for cross-cutting specs. In practice the first
+flow was being used for cross-cutting features too — and that exposed two
+structural problems, both observed concretely on
+[rettx#10](https://github.com/rett-europe/rettx/issues/10) ("rettX Message Center"):
+
+1. **Triage is blind to code.** `iris-triage` classifies from the issue *text*
+   only (a GitHub Models call). It has no visibility into the downstream
+   codebases, which live in separate repos. So when `/route confirm` fanned #10
+   out to `rettxweb`, `rettxadmin`, and `rettxapi`, each repo received the same
+   raw brief with no grounding in what already exists there.
+
+2. **The shared boundary landed in a consumer.** Left to execute independently,
+   `rettxapi` authored the full umbrella spec *and both API contracts* inside its
+   own repo. The contract that `rettxweb` and `rettxadmin` must consume ended up
+   hosted in one of the consumers — the opposite of single-source-of-truth — and
+   a genuine **cross-repo conflict** (three different language-code conventions
+   for the same template-rendering call) went undetected because no one was
+   looking at all three repos at once.
+
+The control plane's distinctive value is exactly that holistic view. A blind,
+text-only fan-out throws it away at the very moment it is most needed.
+
+## Decision
+
+For **cross-cutting** issues (more than one repo, or crossing a trust boundary),
+Iris **no longer auto-fans-out the raw issue**. Instead we insert a
+gap-analysis-and-spec step, owned in the control plane, ahead of fan-out:
+
+```
+issue opened here
+        │
+        ▼
+  Iris triage → labels (route:* / cross-cutting / needs-spec) → posts recommendation
+        │
+        ├─ single-repo, no spec needed ─────────────► /route confirm → iris-route
+        │                                             (raw sub-issue in the one repo)
+        │
+        └─ cross-cutting / needs-spec ──────────────► gap analysis (here)
+                                                              │
+                 read-only orchestrated session per repo,    │
+                 reporting file-grounded findings back        ▼
+                                              spec authored here in specs/NNNN-slug/
+                                              (spec.md + plan.md + research.md +
+                                               contracts/ as the single source of truth)
+                                                              │
+                                                       spec PR merges to main
+                                                              │
+                                                              ▼
+                                              spec-fanout reads the `fanout:` frontmatter
+                                              → one grounded [spec/<slug>] squad issue per repo
+```
+
+Concretely:
+
+- **`iris-route` (raw `/route confirm` fan-out) is reserved for single-repo,
+  no-spec work.** It refuses to run on an issue labelled `cross-cutting` and
+  points the maintainer at the spec pipeline instead.
+- **`iris-triage`** still classifies and labels, but its recommendation comment
+  is branched: for cross-cutting / needs-spec issues it recommends the
+  gap-analysis → spec route and does **not** offer `/route confirm`.
+- **Gap analysis** is performed from the control plane via **read-only
+  orchestrated sessions, one per affected repo**, each reporting file-grounded
+  findings (what exists, what's missing, where new code lands, effort, and any
+  cross-repo conflicts). The findings inform the umbrella spec.
+- **The umbrella spec is authored here** and **hosts the shared API contract**
+  under `specs/NNNN-slug/contracts/`. `rettxapi` *implements and versions* the
+  contract; it does not own its location. The spec's machine-read `fanout:`
+  frontmatter carries a per-repo, gap-informed brief.
+- **`spec-fanout`** (unchanged mechanism) opens the grounded squad issues on
+  merge — but only when the spec's `status` is `ready` or `accepted`, so a
+  `draft` umbrella spec never fans out prematurely.
+
+### Prerequisite — target repos must be main-checkout projects
+
+Gap analysis spawns a session per repo. A session created against a
+**worktree-backed** project fails at creation (`os error 267`, "The directory
+name is invalid"). Every repo that needs gap analysis must therefore be
+registered as a normal **main-checkout** project (e.g. `C:\rettx\rettxadmin`)
+before the orchestration runs. This bit us on the first run (`rettxadmin` had to
+be re-registered) and is now a documented precondition.
+
+## Alternatives considered
+
+### A. Keep the raw `/route confirm` fan-out for everything
+
+Rejected. It is fast but produces ungrounded sub-issues and, as #10 showed, lets
+the shared contract and cross-repo conflicts fall through the cracks. It defeats
+the control plane's reason to exist.
+
+### B. Make `iris-triage` read the downstream code directly
+
+Rejected for now. The triage Action would need cross-repo read tokens and a much
+larger model budget, and it still wouldn't match the depth of a per-repo session
+that can run tools and cite files. The orchestrated-session approach keeps triage
+cheap and puts the deep analysis where the code is.
+
+### C. Author the umbrella spec without a gap-analysis step
+
+Rejected. Without first reading each repo, the umbrella spec repeats the original
+mistake — plausible on paper, wrong in detail (e.g. it would not have caught the
+language-code conflict or the absence of durable async infrastructure in
+`rettxapi`).
+
+## Consequences
+
+### Positive
+
+- Cross-cutting fan-out is **grounded**: each squad issue reflects what actually
+  exists in its repo.
+- The shared contract has a single, neutral home in the control plane; consumers
+  stop redefining it.
+- Cross-repo conflicts surface **before** the lanes diverge, when they are cheap
+  to resolve.
+- `draft` umbrella specs cannot fan out by accident.
+
+### Negative
+
+- Cross-cutting work has a heavier front end (gap analysis + spec authoring)
+  before any downstream issue exists.
+- Requires the main-checkout-project precondition to be satisfied for every
+  target repo before orchestration.
+
+### Neutral
+
+- Single-repo issues are unaffected: `/route confirm` → `iris-route` still works
+  exactly as in ADR 0001.
+- The `spec-fanout` workflow itself is unchanged; only *when* we rely on it
+  (after gap analysis, never after a raw fan-out) changes.
+
+## Follow-ups
+
+- Reflected in `patterns.md` §6 (routing labels) and §7 (spec authoring).
+- Resolve the language-code conflict (decision D1) surfaced by the #10 gap
+  analysis as part of `specs/032-message-center/`.
+- Consider a lightweight `needs-spec` label so triage can mark the gap-analysis
+  path explicitly.

--- a/site/src/content/docs/decisions/0003-message-channel-content-model.md
+++ b/site/src/content/docs/decisions/0003-message-channel-content-model.md
@@ -1,0 +1,165 @@
+---
+title: "ADR 0003 — In-app vs email content model for the Message Center"
+description: "In-app vs email content model for the Message Center"
+sidebar:
+  order: 4
+---
+
+- **Status**: Accepted
+- **Date**: 2026-06-23
+- **Decision-makers**: rettX maintainers
+- **Relates to**: [`specs/032-message-center/`](https://github.com/rett-europe/rettx/blob/main/specs/032-message-center/spec.md)
+  (rendering & content-snapshot requirements), [ADR 0001](https://github.com/rett-europe/rettx/blob/main/docs/adr/0001-control-plane-repo.md)
+
+## Context
+
+The Message Center (spec 032) introduces **persistent in-app messages** alongside
+the pre-existing **transactional email** channel. The same logical message (e.g.
+"welcome") must now be presented in two very different surfaces: a caregiver's
+in-app Message Center *and* an email inbox.
+
+Email content is authored as per-locale templates in the **`templates`** content
+repo, one folder per message type:
+
+```
+emails/welcome/
+  en.html           ← rich, branded HTML email (has <style>, header, footer,
+  en.subject.txt       unsubscribe, CTA buttons) — one per locale
+  de.html
+  de.subject.txt
+  …                 ← ~24 locales
+```
+
+Under the new model, sending a message captures an **immutable content snapshot**
+at send time (SC-008) with per-channel fields on the message record:
+
+| Snapshot field | Feeds | Channel |
+|---|---|---|
+| `subject` | email subject | email |
+| `email_html_body` | the styled HTML | **email** |
+| `in_app_body` | the Message Center detail body | **in-app** |
+| `preview` | a truncation of `in_app_body` | in-app list snippet |
+
+The backend renderer (`rettxapi` `MessageRenderingServices.render`) resolves
+`in_app_body` by precedence:
+
+```
+<locale>.inapp.txt   (dedicated in-app template)
+   └─ else <locale>.text.txt   (plaintext email template)
+        └─ else  html_to_text(<locale>.html)   (derive from the email HTML)
+```
+
+**Today, templates ship only `<locale>.html` + `<locale>.subject.txt`.** No
+in-app or plaintext file exists, so `in_app_body` *always* falls through to the
+HTML→text fallback. That converter strips `<tags>` but historically left the
+inner text of `<style>`/`<script>` blocks behind, so the email stylesheet leaked
+into the in-app body and list preview. Observed on the live welcome message:
+
+> "Welcome to rettX, the European Rett Syndrome patient registry body {
+> font-family: 'Chillax', 'Helvetica Neue', Helvetica, Arial, sans-serif; … }"
+
+This exposed two separate questions: (1) a rendering **bug**, and (2) a
+**strategic** question — should in-app and email content be the same copy in two
+renderings, or intentionally diverge?
+
+## Decision
+
+Adopt a **hybrid channel-content model**:
+
+1. **Default = auto-derive clean in-app text.** When a template has no dedicated
+   in-app file, `in_app_body` is derived from the email template as **clean
+   plaintext**. The HTML→text conversion MUST remove entire `<style>…</style>`
+   and `<script>…</script>` blocks (including inner content) *before* stripping
+   remaining tags. This is the v1 floor and requires no template authoring.
+
+2. **Per-channel authoring on demand.** A template MAY add a dedicated in-app
+   body file **`<locale>.inapp.txt`** (plaintext; markdown is a possible future
+   enhancement). When present, the renderer uses it **verbatim** instead of
+   deriving from the email HTML — letting in-app and email content **intentionally
+   diverge** (in-app: short, no email chrome, app deep-links; email: full branded
+   HTML).
+
+3. **Authoring policy (the "hybrid" rule).** Author `<locale>.inapp.txt` **only
+   where the email is a poor in-app fit** — heavy chrome, CTA buttons, or
+   email-specific framing (e.g. `welcome`, `invitation_email`). Everything else
+   relies on the clean auto-derived text. Adopt incrementally and revisit once
+   the feature is live in production.
+
+4. **Defense in depth on the leak.** Because content snapshots are immutable, the
+   already-sent welcome message keeps its polluted `in_app_body`. The fix is
+   therefore applied at **three** layers:
+   - **Source** — the renderer strips `<style>`/`<script>` before tag-stripping
+     (fixes all *new* messages).
+   - **Read-time guard** — the API model sanitises `preview`/`body` on read
+     (fixes *existing* snapshots without a data migration).
+   - **Frontend** — `rettxweb` keeps its `cleanPreview`/`cleanBody` utilities as
+     a belt-and-suspenders third layer.
+
+5. **No API contract change.** Caregiver `body`/`preview` remain plaintext; the
+   email channel is unchanged. The snapshot stays the single immutable record of
+   what was actually sent.
+
+### Channel content matrix
+
+| Channel | Source (in precedence order) | Format | Authored where |
+|---|---|---|---|
+| Email | `<locale>.html` + `<locale>.subject.txt` | rich HTML | `templates` repo |
+| In-app body | `<locale>.inapp.txt` → `<locale>.text.txt` → cleaned `html_to_text(<locale>.html)` | plaintext | `templates` repo / derived |
+| In-app preview | truncation of `in_app_body` | plaintext | derived |
+
+## Alternatives considered
+
+### A. Auto-derive only — never author in-app templates
+
+Rejected as the *sole* long-term answer. Email copy (unsubscribe footers, CTA
+buttons, "view in browser") reads poorly in-app and cannot be tailored. Retained,
+however, as the **default fallback** for templates that extract cleanly.
+
+### B. Always author a dedicated in-app template for every type × locale
+
+Rejected. ~11 message types × ~24 locales is a large, ongoing authoring burden
+for low marginal value on simple messages whose email already extracts to fine
+plaintext. Forcing it would slow every new message type.
+
+### C. Hybrid — clean auto-derivation by default, dedicated in-app copy where it matters
+
+**Chosen.** Gives a clean in-app experience immediately with zero authoring, and
+an opt-in path to tailored in-app copy exactly where the email is a poor fit,
+adopted incrementally.
+
+## Consequences
+
+### Positive
+
+- In-app messages render clean plaintext immediately — the CSS leak is closed at
+  three layers, covering both new and already-stored messages.
+- In-app copy can be tailored per template/locale without touching the email
+  channel or the API contract.
+- The immutable snapshot (SC-008) remains the single source of truth for what was
+  sent; audit/reproducibility is preserved.
+
+### Negative
+
+- For templates where `inapp.*` is authored, there are now **two** content
+  sources to keep in sync (email vs in-app).
+- Authors must understand the rendering precedence to predict which source wins.
+
+### Neutral
+
+- Existing templates need **no** change to benefit from the clean fallback.
+- In-app divergence is strictly **opt-in** per template and per locale.
+
+## Follow-ups
+
+- **`rettxapi`** — ship the renderer source-clean + read-time guard bugfix PR
+  (in flight): strip `<style>`/`<script>` before tag-stripping; cover new and
+  existing snapshots; tests at both layers.
+- **`rettxweb`** — retain the defensive `cleanPreview`/`cleanBody` utilities.
+- **`templates`** — add `<locale>.inapp.txt` for `welcome` and `invitation_email`
+  first (highest email chrome); document the `inapp.*` convention in the repo
+  README and `deploy.ps1` packaging.
+- **`patterns.md`** — channel-content convention + `inapp.*` naming recorded in §5.
+- **`specs/032-message-center/`** — cross-link the rendering requirements to this
+  ADR.
+- Consider adding the `templates` content repo to `patterns.md` §1 (currently
+  undocumented there).

--- a/site/src/content/docs/decisions/0004-message-center-no-historical-backfill.md
+++ b/site/src/content/docs/decisions/0004-message-center-no-historical-backfill.md
@@ -1,0 +1,103 @@
+---
+title: "ADR 0004 — Message Center launches with no historical backfill"
+description: "Message Center launches with no historical backfill"
+sidebar:
+  order: 5
+---
+
+- **Status**: Accepted
+- **Date**: 2026-06-24
+- **Decision-makers**: rettX maintainers
+- **Relates to**: [`specs/032-message-center/`](https://github.com/rett-europe/rettx/blob/main/specs/032-message-center/),
+  [ADR 0003](https://github.com/rett-europe/rettx/blob/main/docs/adr/0003-message-channel-content-model.md) (channel content model)
+
+## Context
+
+The caregiver Message Center (`specs/032-message-center/`) is feature-complete and
+signed off for go-live. The in-app inbox is backed by a new store in `rettxapi`: each
+message is an **immutable per-recipient content snapshot** (SC-008) carrying a clean
+`in_app_body`, a controlled `category_code` (`MessageCategory`, exactly 10 values), a
+`recipient_principal_id`, timestamps, and read / archive state.
+
+Before this feature existed, the platform already communicated with caregivers — most
+notably the **welcome email** and other transactional sends — delivered as **emails**
+through the templates repo (`c:\rettx\templates`) and `rettxapi`'s `EmailServices`.
+Those historical sends were **never persisted as in-app message snapshots**; they only
+ever existed as email.
+
+At go-live we must decide whether to **backfill** those historical sends into the new
+message container so they appear retroactively in each caregiver's inbox, or **start
+fresh** with an empty inbox that fills only from new sends going forward.
+
+## Decision
+
+**Start fresh. The Message Center launches with no historical backfill.** The caregiver
+inbox begins empty for every user and populates only from messages sent **after**
+go-live through the new pipeline. No migration job runs against historical email sends.
+
+This is a `rettxapi` data decision; per the control-plane cross-repo rules it is
+**captured here** and the API lane executes (or, in this case, deliberately does not
+execute) the corresponding migration. No code in any consumer repo changes.
+
+## Rationale
+
+1. **No in-app snapshot exists for historical sends.** Old messages went out as email
+   only. A backfill would have to **re-derive** `in_app_body` from stored email HTML —
+   exactly the path that produced the CSS-leak defect fixed in ADR 0003 / rettxapi #305.
+   Reconstructing snapshots from legacy HTML re-introduces that risk for the lowest-value
+   content.
+2. **Read / archive state is unknown.** Historical items would import as **unread**,
+   confronting every caregiver with a wall of unread badges (e.g. "47 unread") on first
+   open — a poor first impression that could also re-trigger unread-count side effects.
+3. **No `category_code`.** The frozen contract requires it, but pre-feature sends predate
+   the controlled vocabulary, so nearly everything maps to `DEFAULT` ("Notification") —
+   low value and visibly unfinished.
+4. **Nothing is lost.** The historical emails still live in recipients' own email
+   inboxes. Starting fresh destroys no record; it simply declines to retro-fit them into
+   a surface they were never authored for.
+5. **Effort vs. value.** Reconstituting recipient lists, content, timestamps, and state
+   for a clean import is non-trivial, while caregivers do not expect old transactional
+   emails to retroactively appear in a brand-new inbox.
+
+## Alternatives considered
+
+### A. Full backfill of all historical sends
+Rejected. Maximises every risk above (legacy-HTML re-derivation, all-unread flood,
+`DEFAULT` category sprawl) for content users don't expect to see in-app.
+
+### B. Narrow curated backfill (e.g. welcome message per active caregiver)
+Considered and **deferred, not adopted**. A tightly scoped import — only the welcome
+message, marked **already-read**, category `onboarding`, body produced via the clean
+ADR 0003 `inapp` derivation rather than legacy HTML — would avoid the unread flood and
+the CSS-leak path while giving the inbox a non-empty "here's your history" feel. It was
+set aside to keep go-live clean and unblocked. It remains the obvious first step **if**
+a future need for in-app message history arises (see Follow-ups), and this ADR can be
+revisited rather than re-litigated.
+
+## Consequences
+
+### Positive
+- Cleanest, lowest-risk launch: no migration job, no legacy-HTML re-derivation, no
+  day-one unread flood.
+- The inbox only ever shows content authored for the in-app channel under the frozen
+  contract — consistent category and clean body for every item.
+
+### Negative
+- Caregivers see **no history** at launch; the inbox is empty until the first new send.
+  Early adopters may briefly perceive the feature as "empty".
+
+### Neutral
+- Reversible in spirit: a future curated backfill (Alternative B) can still be run later
+  without conflicting with anything decided here.
+- No consumer-repo (`rettxweb` / `rettxadmin`) impact; this is purely a `rettxapi`
+  data-population decision.
+
+## Follow-ups
+
+- `rettxapi`: **no** backfill/migration script for go-live (explicit non-action).
+- If in-app message **history** is later desired, implement Alternative B as a scoped,
+  idempotent, already-read import using the ADR 0003 `inapp` derivation — not a raw
+  legacy-HTML re-derivation — and revisit this ADR's status.
+- Consider a first-run **empty-state** treatment in `rettxweb` that frames an empty inbox
+  positively ("You're all caught up — new messages will appear here") so the fresh start
+  reads as intentional rather than broken.

--- a/site/src/content/docs/decisions/0005-message-center-rollout-pilot-then-default-on.md
+++ b/site/src/content/docs/decisions/0005-message-center-rollout-pilot-then-default-on.md
@@ -1,0 +1,155 @@
+---
+title: "ADR 0005 — Message Center rollout: per-user pilot, then default-on for all"
+description: "Message Center rollout: per-user pilot, then default-on for all"
+sidebar:
+  order: 6
+---
+
+- **Status**: Accepted — implemented 2026-06-25
+- **Date**: 2026-06-24 (implementation outcome appended 2026-06-25)
+- **Decision-makers**: rettX maintainers
+- **Relates to**: [`specs/032-message-center/`](https://github.com/rett-europe/rettx/blob/main/specs/032-message-center/),
+  [ADR 0004](https://github.com/rett-europe/rettx/blob/main/docs/adr/0004-message-center-no-historical-backfill.md) (no historical backfill)
+
+## Context
+
+The caregiver Message Center is deployed to **production but dark** — the caregiver
+in-app feature is gated behind a feature flag named **`messages`** that defaults **off**.
+The caregiver web app (`rettxweb`) gates content on this flag
+(`featureMatchGuard('messages')` / `isMessagesContentEnabled`); the flag's real value is
+per-user, sourced from the user's profile/entitlements via `rettxapi`.
+
+Two things need to happen for go-live, and they happen at **different times**:
+
+1. We want to **pilot** with a small number of real caregivers in production before
+   exposing the feature broadly.
+2. Once the pilot looks good, we want the feature **on by default for everyone**.
+
+At the moment, neither is operable: the `messages` flag is **not surfaced in the
+rettxadmin Users screen**, so an admin cannot enable it for even a single pilot user.
+
+## Decision
+
+Roll out in **two explicit phases**, and build only Phase A now.
+
+### Phase A — per-user pilot (now)
+- Surface the `messages` feature flag as a **per-user toggle in the rettxadmin Users
+  screen**, writing through to the same store the caregiver app reads.
+- The global default stays **off**. Pilot caregivers are enabled **individually** by an
+  admin.
+- This is the immediate go-live-blocker fix and is owned by the `rettxadmin` lane (with
+  an `rettxapi` change only if the per-user flag field does not already exist
+  server-side).
+
+### Phase B — default-on for all (later, on explicit maintainer go)
+- Once the pilot is validated, flip the feature to **on by default for all users** with a
+  **single, low-risk switch** — effectively ungating the feature.
+- **No per-user exceptions are required after the global flip.** Once it is on for all, it
+  is on for everyone. We therefore do **not** build tri-state / "explicit-off-wins"
+  override semantics; the per-user flag exists only to drive the pilot.
+- The exact location of the Phase-B switch (the `rettxweb` gate defaulting to
+  true / being removed, **or** `rettxapi` resolving `messages` to true by default) is to
+  be **identified and documented during Phase A** so the flip is a known one-liner, not a
+  rebuild. If it lives in `rettxapi`, that change is routed when the maintainer calls the
+  global go.
+
+## Flag-key consistency (non-negotiable)
+
+The caregiver app reads a flag literally named **`messages`**. Every layer — admin write,
+storage, caregiver read — must use this **same key** end to end. A mismatch (e.g. admin
+writes `message_center`, web reads `messages`) silently no-ops the toggle. Phase A must
+verify the full path before sign-off.
+
+## Implementation outcome (2026-06-25)
+
+Both phases shipped; the cutover is **live in production**.
+
+**Phase A — done.** The per-user `messages` toggle was added to the rettxadmin Users
+screen (`rettxadmin` PR #50: one entry in `AVAILABLE_FEATURES`). The flag-key path was
+verified end to end — admin writes `app_metadata.features.messages` via
+`PATCH /admin/principals/{id}/features`; the caregiver app reads the **same key** off the
+resolved profile. No `rettxapi` change was needed for Phase A. Pilot caregivers were
+enabled individually and the pilot was validated.
+
+**Phase B — done, as a single `rettxapi` resolution switch.** On the maintainer's explicit
+go, `messages` was made **on for all caregivers**:
+
+- The switch lives in `rettxapi`, **not** `rettxweb` — the caregiver app reads
+  `app_metadata.features.messages` off the resolved profile, so defaulting it server-side
+  lights up both `rettxweb` gates (route guard + unread badge) with **no web redeploy** and
+  no dead frontend code. A frontend ungate (`rettxweb` PR #169) was prepared as a fallback
+  and **closed unused** once the read path was confirmed to be API-resolved (no Auth0/JWT
+  claim source).
+- First cut (`rettxapi` PR #306) defaulted `messages` to `true` **only when unset**. This
+  proved **insufficient**: pilot/admin-touched accounts carried an **explicit stored
+  `messages: false`** — the rettxadmin Users screen PATCHes the full known-flag map with
+  replace semantics, so saving a user while the toggle was off persisted `false`. Those
+  accounts stayed dark.
+- Final cut (`rettxapi` PR #307, **supersedes #306**) **forces `messages = true`
+  regardless of the stored value**, realising this ADR's "no per-user exceptions". It is
+  applied at the response builder
+  (`principal_profile_services._map_principal_to_response`), the single funnel for
+  `GET`/`PATCH /user/profile`. Deliberately **not** at the `FeaturesFlags` model level: the
+  per-request `update_last_seen_at` full-document upsert would have stealth-migrated
+  `messages: true` into stored docs. The response-layer override applies **on read only —
+  non-destructive, no data migration**. One-line revert: delete
+  `features_dict["messages"] = True`.
+
+**Consequence — admin toggle retired.** Because caregiver visibility is now forced on
+server-side, the rettxadmin Messages toggle is a no-op and is being **removed** (revert of
+PR #50). Stored `messages` values are left as-is (harmless; overridden on read). Re-adding
+the toggle entry is how a per-user switch would be restored if force-on is ever reverted.
+
+This is consistent with the original decision (single low-risk switch, no migration, no
+per-user exceptions); the only refinement is that realising "on for everyone" required
+**force-true**, not merely default-when-unset, because explicit `false` values already
+existed in the pilot cohort.
+
+## Alternatives considered
+
+### A. Skip the pilot — flip default-on at launch
+Rejected. The feature is new and clinically adjacent; a controlled pilot with real users
+in production de-risks content, i18n drafts (per ADR-adjacent i18n decision: go live on
+machine-translated drafts with native review in parallel), and UX before broad exposure.
+
+### B. Tri-state flag with per-user override that survives the global flip
+Considered and **not adopted**. It would let an admin force specific users off even after
+default-on. The maintainer confirmed this is unnecessary — once on for all, it is on for
+everyone — so the simpler per-user-flag-for-pilot model is chosen to avoid building and
+maintaining override-resolution logic.
+
+### C. Bulk-set `messages = true` on every user row at Phase B
+Rejected as the mechanism. Mutating every user record is messier and less reversible than
+a single default/gate switch. Phase B should be one switch, not a data migration.
+
+## Consequences
+
+### Positive
+- Safe, staged exposure: a few real users first, broad rollout second.
+- Phase A unblocks enablement immediately (admin can flip pilot users).
+- Phase B is deliberately kept to a single, documented, low-risk change.
+- The simplified (no-exception) model avoids override-resolution complexity.
+
+### Negative
+- The feature reaches all users in **two steps** with a manual maintainer decision
+  between them, rather than at a single launch moment.
+- Until Phase B, enablement is manual and per-user (fine for a small pilot, not for
+  scale — which is exactly why Phase B exists).
+
+### Neutral
+- This ADR governs **enablement/cutover only**; content behaviour, contracts, and the
+  no-backfill decision (ADR 0004) are unchanged.
+- Phase B's go is a separate, explicit maintainer instruction; nothing here authorises an
+  automatic global flip.
+
+## Follow-ups
+
+- `rettxadmin`: ~~surface the per-user `messages` toggle in the Users screen (Phase A)~~
+  **done (PR #50)**; key path verified. **Pending:** remove the now-redundant Messages
+  toggle entry (revert of PR #50) since Phase-B force-on makes it a no-op.
+- `rettxweb`: ~~confirm the gate is the single place a flip would touch~~ **done** — gates
+  are `featureMatchGuard('messages')` + `isMessagesContentEnabled`, both reading the
+  resolved profile; the Phase-B switch landed in `rettxapi` instead, so no `rettxweb`
+  change shipped (fallback PR #169 closed unused).
+- ~~When the maintainer calls the global go, route the Phase-B switch~~ **done** — Phase B
+  shipped via `rettxapi` PR #306 → #307 (force-on); deployed to production 2026-06-25.

--- a/site/src/content/docs/decisions/0006-message-center-template-store-layout.md
+++ b/site/src/content/docs/decisions/0006-message-center-template-store-layout.md
@@ -1,0 +1,164 @@
+---
+title: "ADR 0006 — Message Center template store: multi-channel layout & naming"
+description: "Message Center template store: multi-channel layout & naming"
+sidebar:
+  order: 7
+---
+
+- **Status**: Accepted (2026-07-11)
+- **Date**: 2026-07-11
+- **Decision-makers**: rettX maintainers
+- **Relates to**: [ADR 0003](https://github.com/rett-europe/rettx/blob/main/docs/adr/0003-message-channel-content-model.md) (channel
+  content model), [`specs/032-message-center/`](https://github.com/rett-europe/rettx/blob/main/specs/032-message-center/spec.md),
+  [`specs/033-message-center-push/`](https://github.com/rett-europe/rettx/blob/main/specs/033-message-center-push/spec.md)
+  (push channel), [`patterns.md` §1 *Content* / §5](https://github.com/rett-europe/rettx/blob/main/.specify/memory/patterns.md)
+
+## Context
+
+The `templates` content repo (`rett-europe/templates`) holds the per-locale
+Message Center message templates. They live in a top-level folder called
+**`emails/`**, one subfolder per message type:
+
+```
+emails/welcome/
+  en.html                 ← branded HTML email body
+  en.subject.txt          ← email subject
+  en.inapp.txt            ← (optional, ADR 0003) dedicated in-app body
+  en.push.subject.txt     ← (new, spec 033) push title
+  en.push.txt             ← (new, spec 033) push body
+```
+
+When the folder was created (spec 032) it held only email content, so `emails/`
+was an accurate name. It has since become the store for **all three Message
+Center channels** — email, in-app (ADR 0003), and now Android **push** (spec
+033). The folder name `emails/` is therefore now a **misnomer**: it holds
+multi-channel message content, not just emails. The same is true of the blob
+**container** it deploys to, `email-templates`.
+
+This ADR exists because that misnomer surfaced during the push rollout and
+raised a fair question: *should the template store be refactored?* Before
+answering, it is essential to separate what is **cosmetic** from what is
+**load-bearing**, because they carry very different migration cost and risk.
+
+### What is actually coupled (and what is not)
+
+The deploy is a **full sync with delete**
+(`templates/.github/workflows/deploy-email-templates.yml`):
+
+```
+az storage blob sync --source ./emails --container email-templates \
+    --delete-destination true
+```
+
+- The **`emails/` prefix is stripped at deploy.** `emails/welcome/en.html`
+  becomes blob `welcome/en.html`. The source folder name **never reaches the
+  blob store or `rettxapi`** — it is a pure repo-local label.
+- **`rettxapi` reads from the blob container** (`email-templates`, configured via
+  env `RETTX_STORAGE_EMAIL_TEMPLATE_CONTAINER`) by the path convention
+  `<type>/<locale>.<suffix>`. It has no knowledge of the `emails/` folder.
+- Because the sync uses `--delete-destination true`, **the container mirrors the
+  source exactly**: any change to the *blob path layout* (not just the folder
+  name) is applied destructively — old paths are deleted on the next deploy.
+
+This gives three distinct levers, in ascending order of cost:
+
+| Lever | What changes | Touches `rettxapi`? | Blob paths change? | Risk |
+|---|---|---|---|---|
+| **(a)** Source folder `emails/` → e.g. `messages/` | repo label + deploy `--source` path + `deploy.ps1` | No | No (prefix stripped either way) | Trivial |
+| **(b)** File-naming convention (e.g. group by channel) | blob paths + `rettxapi` resolver | **Yes** | **Yes** | High (see migration hazard) |
+| **(c)** Blob container `email-templates` → e.g. `message-templates` | container + `rettxapi` env in every environment + data migration | **Yes** | n/a | High (cross-repo, multi-env) |
+
+### Migration hazard (why (b)/(c) are not free)
+
+`--delete-destination true` means a blob-path restructure is **not** additive: on
+the first deploy after the change, the *old* paths are deleted while `rettxapi`
+in production still expects them. Any restructure of blob paths or the container
+name therefore requires a **coordinated cutover** — `rettxapi` must be able to
+read the new layout **before** the templates repo deploys it — or a dual-read /
+dual-write window. This is the core reason the current flat `<type>/<locale>.<suffix>`
+convention is worth preserving unless there is a strong driver to change it.
+
+## Decision drivers
+
+- **Clarity** — a newcomer should not read `emails/` and assume it is email-only.
+- **Low migration risk** — avoid destructive, cross-repo, multi-environment
+  changes for cosmetic gain, especially mid-pilot.
+- **Channel-extensibility** — the scheme should absorb a *fourth* channel later
+  without another migration. (It already absorbed push cleanly via the
+  `.push.` infix.)
+- **Backward compatibility** — the push fix (spec 033) just shipped under the
+  current convention; a refactor must not regress it.
+- **Consistency with governance** — `templates` is now a first-class routable
+  repo (`patterns.md` §1 *Content*); changes to its contract flow through spec +
+  ADR, not ad-hoc renames.
+
+## Options
+
+### Option 0 — Status quo (keep `emails/` + flat suffix convention)
+No change. `emails/` stays a mild misnomer; the flat `<type>/<locale>.<suffix>`
+convention (with `.subject.txt`, `.inapp.txt`, `.push.subject.txt`, `.push.txt`
+infixes) continues. Zero risk, zero clarity gain.
+
+### Option 1 — Rename the source folder only (`emails/` → `messages/`) **[recommended]**
+Rename the repo folder and update `--source ./emails` (deploy workflow) and
+`deploy.ps1`. Blob paths and the container name are **unchanged** (prefix is
+stripped), so `rettxapi` is untouched and there is no cutover. Pure clarity win;
+the folder name finally reflects "multi-channel Message Center message content".
+Optionally add a repo `README` documenting the per-channel file convention.
+
+### Option 2 — Restructure to a channel-grouped layout
+e.g. `<type>/<locale>/{email.html,email.subject.txt,inapp.txt,push.title.txt,push.body.txt}`.
+Cleaner mental model, but changes **blob paths** → requires a `rettxapi` resolver
+change and a coordinated destructive cutover (see hazard). Higher value, much
+higher cost; only justified if the flat convention becomes genuinely unwieldy.
+
+### Option 3 — Rename the blob container (`email-templates` → `message-templates`)
+The most "correct" rename, but the most expensive: container migration plus
+`rettxapi` env changes across dev/pre/prod and a redeploy. Low ROI for a name
+that is invisible to end users.
+
+## Recommendation
+
+Adopt **Option 1 now** (rename the source folder to `messages/`, container and
+blob layout unchanged) as a cheap, zero-risk clarity fix, and **defer Options 2
+and 3** unless a concrete need arises. Keep the flat `<type>/<locale>.<suffix>`
+file convention: it is channel-extensible (it absorbed push without a migration)
+and avoids the sync-with-delete cutover hazard. Record the per-channel file
+convention explicitly (this ADR + a `templates` README + `patterns.md` §5) so the
+naming is self-documenting regardless of the folder label.
+
+> This ADR is **Accepted** (2026-07-11). The `patterns.md` convention/`messages/`
+> documentation lands with this ADR (control-plane PR #27); the folder rename
+> itself is executed as a `templates` repo slice (its own PR) — the container and
+> blob paths are unchanged, so `rettxapi` needs no change.
+
+## Consequences
+
+### Positive
+- The store name reflects reality (multi-channel), removing the `emails/`
+  misnomer with no runtime risk.
+- The load-bearing coupling (blob container + flat path convention consumed by
+  `rettxapi`) is preserved, so nothing has to be re-authored or migrated.
+- The per-channel file convention becomes documented and self-explanatory.
+
+### Negative
+- A folder rename touches every path in the `templates` repo's deploy config and
+  any local tooling that hard-codes `emails/` (small, contained).
+- The container name `email-templates` remains a residual misnomer (accepted;
+  Option 3 deferred).
+
+### Neutral
+- No `rettxapi` change and no blob migration under the recommended option.
+- Options 2/3 remain available later behind a proper coordinated cutover if the
+  flat convention or container name ever becomes a real pain point.
+
+## Follow-ups (on acceptance)
+- **`templates`** — rename `emails/` → `messages/`; update
+  `deploy-email-templates.yml` (`--source`) and `deploy.ps1`; add a `README`
+  documenting the `<type>/<locale>.<suffix>` per-channel convention
+  (`.html`, `.subject.txt`, `.inapp.txt`, `.push.subject.txt`, `.push.txt`).
+- **`patterns.md`** — §1 *Content* / §5: note the folder is `messages/` and
+  record the per-channel file-suffix convention explicitly.
+- **`rettxapi`** — no change required under Option 1 (documentation cross-link
+  only). If Options 2/3 are ever adopted, that work is gated on a coordinated
+  resolver/env cutover captured in a superseding ADR.

--- a/site/src/content/docs/decisions/0007-ai-code-review-custom-instructions.md
+++ b/site/src/content/docs/decisions/0007-ai-code-review-custom-instructions.md
@@ -1,0 +1,168 @@
+---
+title: "ADR 0007 — AI code-review custom instructions across the ecosystem"
+description: "AI code-review custom instructions across the ecosystem"
+sidebar:
+  order: 8
+---
+
+- **Status**: Accepted (2026-07-11)
+- **Date**: 2026-07-11
+- **Decision-makers**: rettX maintainers
+- **Relates to**: [ADR 0001](https://github.com/rett-europe/rettx/blob/main/docs/adr/0001-control-plane-repo.md) (control plane &
+  per-repo ownership), [`patterns.md` §10](https://github.com/rett-europe/rettx/blob/main/.specify/memory/patterns.md),
+  [program constitution](https://github.com/rett-europe/rettx/blob/main/.specify/memory/constitution.md) (PHI / privacy
+  non-negotiables), GitHub docs:
+  [Adding repository custom instructions](https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/add-custom-instructions/add-repository-instructions)
+
+## Context
+
+We use **GitHub Copilot code review** on pull requests across the ecosystem
+repos (recent examples: `rettxapi#311`, `rettxweb#181`). Copilot code review
+consumes a repo's **custom instructions** when generating a review, so those
+files are the lever for making automated review enforce *our* conventions
+rather than only generic best practice.
+
+GitHub supports three instruction types (per the docs above):
+
+- **Repository-wide** — `.github/copilot-instructions.md`. Applies to every
+  request in the repo, including code review.
+- **Path-specific** — one or more `NAME.instructions.md` files under
+  `.github/instructions/`, each with YAML frontmatter `applyTo: "<glob>"`.
+  Applied when the reviewed file matches the glob; combined with the
+  repo-wide file when both exist.
+- **Agent** — `AGENTS.md` (or a single `CLAUDE.md` / `GEMINI.md`), used by AI
+  coding agents rather than by code review.
+
+For Copilot code review, the "use custom instructions" preference must be
+enabled — it is **on by default**.
+
+An audit of the seven ecosystem repos (`rettx`, `rettxweb`, `rettxadmin`,
+`rettxapi`, `rettxmutation`, `rettxid`, `templates`) on 2026-07-11 found:
+
+- **All seven already have** `.github/copilot-instructions.md` **and**
+  `AGENTS.md`. The plumbing exists everywhere.
+- **Content is uneven and mostly agent-/onboarding-oriented, not
+  review-oriented.** Example: `rettxweb`'s file is Spec Kit auto-generated (a
+  technology inventory, "Code Style: follow standard conventions", a recent-
+  changes log) plus a large spec-drafting-mode block — almost nothing that
+  tells a *reviewer* what to flag.
+- **Where good review rules exist, they can be mis-encoded.** `rettxapi`'s file
+  carries genuinely useful, enforceable rules (repository-layer exceptions,
+  "do not modify source to make a test pass"), but it opens with
+  `applyTo: "*.py"` frontmatter — which is only meaningful in a
+  `.github/instructions/*.instructions.md` file and is inert in the repo-wide
+  file.
+- **No repo uses path-specific `.github/instructions/` files at all**, so the
+  mechanism designed for "apply these rules when reviewing files of this kind"
+  is unused.
+
+Net: automated review quality varies per repo, and our house non-negotiables
+(PHI/privacy, auth boundaries, i18n completeness, API-contract ownership, test
+integrity) are not reliably enforced by the reviewer.
+
+## Decision
+
+Adopt an ecosystem-wide standard: **every repo maintains review-focused Copilot
+custom instructions**, structured as follows.
+
+1. **Repo-wide file is mandatory and must be review-oriented.**
+   `.github/copilot-instructions.md` MUST contain a clearly-marked section of
+   **enforceable review conventions** — statements a reviewer can check a diff
+   against ("repository methods raise domain exceptions from `app.exceptions`,
+   never `HTTPException`"), not a technology inventory or a changelog. The Spec
+   Kit auto-generated block MAY remain, but the review conventions live in an
+   explicit, human-owned section.
+
+2. **Path-specific rules go in `.github/instructions/`, not the repo-wide
+   file.** Language/area-scoped rules use
+   `.github/instructions/<area>.instructions.md` with `applyTo:` frontmatter
+   (e.g. `applyTo: "**/*.py"`). `applyTo:` MUST NOT appear in
+   `copilot-instructions.md` (it is inert there) — fixing `rettxapi`'s current
+   mis-placement is part of rollout.
+
+3. **Content rules.** Keep files **concise** (long instructions get truncated
+   and diluted). Prefer imperative, checkable rules. Cover the repo's own
+   non-negotiables **plus** the cross-cutting constants every repo shares:
+   **no PHI in code, logs, tests, or examples** (constitution); auth/trust
+   boundaries; full supported-language set for user-facing strings
+   (`patterns.md` §5); API-contract ownership (contracts live in `rettxapi`,
+   consumers don't fork them — `patterns.md` §3); and test integrity (don't
+   change source just to make a test pass). **Reference** the repo constitution
+   and control-plane `patterns.md` rather than duplicating them, so there is a
+   single source of truth.
+
+4. **No divergence between instruction files.** Review conventions have one
+   canonical home per repo (the repo-wide file and/or `.github/instructions/`).
+   `AGENTS.md`/`CLAUDE.md` may point at it, but the same rule must not be
+   maintained in two places with drift.
+
+5. **Keep the setting on.** The "use custom instructions for Copilot code
+   review" preference stays enabled (default). Rollout verifies this per repo/
+   org.
+
+This ADR sets the **standard and the control-plane template**; it does not by
+itself rewrite the six downstream files — that is a fan-out (see Follow-ups),
+executed per repo since each repo owns its own conventions and Copilot reads
+each repo's files independently.
+
+## Options considered
+
+- **Option A — repo-wide file only (baseline).** A single strong
+  `copilot-instructions.md` per repo. Simplest; sufficient for small/uniform
+  repos.
+- **Option B — repo-wide + path-specific (recommended target).** Repo-wide file
+  for cross-file rules, plus `.github/instructions/*.instructions.md` where a
+  repo has clear language/area splits (e.g. `rettxapi` Python rules, a web
+  repo's `*.spec.ts` test rules). Best signal-to-noise for review.
+- **Option C — centralize all conventions in the control plane.** Rejected:
+  Copilot code review reads the **target repo's** files only; it cannot read
+  another repo. Per-repo files are structurally required, so the control plane
+  can define the standard and cross-cutting text but cannot host the operative
+  files for other repos.
+
+## Recommendation
+
+Adopt **Option A as the floor everywhere** and **Option B where a repo has a
+natural area split**. Concretely:
+
+- Control plane publishes a short **skeleton** (`copilot-instructions.md`
+  section headings + a starter set of cross-cutting rules) and records the
+  standard in `patterns.md` §10.
+- Each repo's file gains a **"Conventions Copilot must enforce in review"**
+  section seeded from its constitution + `patterns.md`.
+- `rettxapi` moves its `*.py` rules into
+  `.github/instructions/python.instructions.md` (correct `applyTo:` home) and
+  keeps cross-file rules in the repo-wide file.
+- `rettxweb` gains real review conventions beyond the auto-generated tech list.
+
+## Consequences
+
+### Positive
+- Automated review enforces house conventions (PHI, layering, contracts, i18n,
+  test integrity), not just generic advice — consistently across repos.
+- The `applyTo:` mechanism is used correctly, so path-scoped rules actually fire.
+- One canonical home per rule reduces drift between agent and review guidance.
+
+### Negative / cost
+- Six downstream files to author/upgrade and then keep current as conventions
+  evolve (bounded; each is small).
+- Over-long or stale instructions can *hurt* review quality, so files must stay
+  concise and be maintained.
+
+### Neutral
+- No change to runtime code or CI. Existing `AGENTS.md`/`CLAUDE.md` files stay;
+  they are only cross-referenced, not deleted.
+
+## Follow-ups (on acceptance)
+
+- **Control plane (this PR)** — record the standard in `patterns.md` §10 and
+  link this ADR. Optionally add a starter skeleton under `.specify/templates/`.
+- **Fan-out (gated on maintainer go-ahead)** — a slice per downstream repo
+  (`rettxweb`, `rettxapi`, `rettxadmin`, `rettxmutation`, `rettxid`,
+  `templates`) to add/upgrade the review-focused section, and to introduce
+  `.github/instructions/*.instructions.md` where Option B applies. Track under
+  the cross-cutting routing process (`route:*` / `squad`).
+- **`rettxapi`** — move the stray `applyTo: "*.py"` block from
+  `copilot-instructions.md` into `.github/instructions/python.instructions.md`.
+- **Settings** — confirm the Copilot code-review custom-instructions preference
+  is enabled at the org/repo level.

--- a/site/src/content/docs/decisions/0008-retire-autonomous-squad-agent-system.md
+++ b/site/src/content/docs/decisions/0008-retire-autonomous-squad-agent-system.md
@@ -1,0 +1,101 @@
+---
+title: "ADR 0008 — Retire the autonomous Squad/Ralph agent system"
+description: "Retire the autonomous Squad/Ralph agent system"
+sidebar:
+  order: 9
+---
+
+- **Status**: Accepted (2026-07-11)
+- **Date**: 2026-07-11
+- **Decision-makers**: rettX maintainers
+- **Relates to**: [ADR 0002](https://github.com/rett-europe/rettx/blob/main/docs/adr/0002-cross-cutting-gap-analysis-pipeline.md)
+  (gap-analysis → umbrella spec → `spec-fanout` orchestration pipeline),
+  [`patterns.md` §6](https://github.com/rett-europe/rettx/blob/main/.specify/memory/patterns.md) (issue routing labels)
+
+## Context
+
+Each downstream execution repo (`rettxapi`, `rettxweb`, `rettxadmin`) shipped a
+self-contained **Squad** toolkit — colloquially "Ralph" — that let a set of
+autonomous agents act on issues without a human in the loop. It consisted of:
+
+- Four GitHub Actions workflows: `squad-heartbeat.yml`, `squad-issue-assign.yml`,
+  `squad-triage.yml`, and `sync-squad-labels.yml`.
+- A `.squad/` directory holding Star-Wars-named agent **charters**, **ceremonies**,
+  **routing** rules, and **config** that told those agents how to self-assign,
+  triage, and begin work.
+
+The system watched for issues labelled `squad` (the fan-out inbox label applied by
+the control-plane `spec-fanout` workflow) and would auto-assign, triage, and start
+work on them. Its heartbeat and triage jobs ran on **every PR and push**, producing
+a steady stream of CI noise and bot chatter that was disproportionate to the value
+it delivered. In practice the autonomous behaviour was hard to reason about: two
+overlapping coordination models (autonomous Squad vs. human orchestration) existed
+side by side, and the Squad path frequently acted on issues in ways a maintainer
+then had to correct.
+
+Meanwhile the program adopted a **session-based orchestration** model. Under
+[ADR 0002](https://github.com/rett-europe/rettx/blob/main/docs/adr/0002-cross-cutting-gap-analysis-pipeline.md), cross-cutting work is
+gap-analysed and specced in the control plane, then fanned out; a human coordinator
+opens the resulting issues/specs and **spawns one working session per repo**, each
+landing its own PR. That model already covers everything the Squad system was meant
+to do — and does it with a clear, auditable, one-session-one-branch-one-PR shape —
+so the autonomous layer became redundant overhead.
+
+## Decision
+
+**Retire the autonomous Squad/Ralph system.**
+
+- **Delete** the four `squad-*.yml` workflows (`squad-heartbeat.yml`,
+  `squad-issue-assign.yml`, `squad-triage.yml`, `sync-squad-labels.yml`) and the
+  `.squad/` directory from every downstream repo that carried them. The removal
+  also sweeps up the **companion artifacts** the toolkit installed: the Squad
+  **Coordinator** agent (`.github/agents/squad.agent.md`) and, in `rettxweb` and
+  `rettxadmin`, the six Squad-coupled Copilot skills under `.copilot/skills/`.
+- **Keep the `squad` GitHub label.** It is unchanged as a routing artifact: the
+  control-plane `spec-fanout` workflow still applies it to each `[spec/<slug>]`
+  downstream issue. What changes is that the label **no longer triggers any
+  automation**. It is now purely the **fan-out inbox** marker — a human/orchestrated
+  working session picks the issue up rather than an autonomous agent.
+- **Retain the spec-kit workflows.** The control-plane pipeline
+  (`issue-to-spec` / `spec-to-branch` / `spec-pr-guard`, and the `spec-fanout`
+  fan-out itself) is unaffected. Downstream repos keep their local spec-kit
+  commands; only the autonomous Squad layer on top of them is removed.
+
+### Scope
+
+Repos cleaned up by this decision:
+
+- `rettxapi`
+- `rettxweb`
+- `rettxadmin`
+
+`rettxid`, `rettxmutation`, and `templates` never carried the Squad toolkit, so
+there is nothing to remove there.
+
+Implementation PRs:
+
+- `rettxapi` — [rett-europe/rettxapi#312](https://github.com/rett-europe/rettxapi/pull/312)
+- `rettxweb` — [rett-europe/rettxweb#182](https://github.com/rett-europe/rettxweb/pull/182)
+- `rettxadmin` — [rett-europe/rettxadmin#55](https://github.com/rett-europe/rettxadmin/pull/55)
+
+## Consequences
+
+### Positive
+
+- **Less CI noise.** The heartbeat/triage jobs no longer run on every PR and push.
+- **One coordination model.** Session-based orchestration (ADR 0002) is now the
+  single way cross-cutting work is picked up and executed — no competing autonomous
+  path.
+- **Simpler mental model.** A maintainer reads a `squad`-labelled issue as an inbox
+  item to pick up, not as something a bot may already be acting on.
+
+### Negative / neutral
+
+- **No more auto-assignment or auto-triage** in the downstream repos; a human must
+  now spawn a session to act on a `squad` issue.
+- The `squad:<member>` **sub-labels become orphaned metadata** — they no longer map
+  to any active agent. They can be pruned opportunistically; leaving them in place
+  is harmless.
+- Downstream `squad` issues now **require a human/orchestrated session** to move
+  forward. This is intentional: the pickup is deliberate and auditable rather than
+  automatic.

--- a/site/src/content/docs/decisions/0009-pulse-menstrual-period-duration-model.md
+++ b/site/src/content/docs/decisions/0009-pulse-menstrual-period-duration-model.md
@@ -1,0 +1,118 @@
+---
+title: "ADR 0009 — Pulse menstrual period modelled as start + duration"
+description: "Pulse menstrual period modelled as start + duration"
+sidebar:
+  order: 10
+---
+
+- **Status**: Proposed (2026-07-22)
+- **Date**: 2026-07-22
+- **Decision-makers**: rettX maintainers
+- **Relates to**: [spec 037](https://github.com/rett-europe/rettx/blob/main/specs/037-pulse-menstrual-duration/spec.md)
+  (rettX Pulse — Menstrual Period as Start + Duration),
+  [spec 035 — rettX Pulse](https://github.com/rett-europe/rettx/blob/main/specs/035-pulse-tracker/spec.md) (the umbrella
+  Pulse tracker spec this amends), [ADR 0002](https://github.com/rett-europe/rettx/blob/main/docs/adr/0002-cross-cutting-gap-analysis-pipeline.md)
+  (spec → `spec-fanout` orchestration), rettxweb#231 and rettxweb#229 (the live bugs
+  that surfaced this)
+- **Supersedes**: the menstrual preset of the merged umbrella spec
+  **[035 — rettX Pulse](https://github.com/rett-europe/rettx/blob/main/specs/035-pulse-tracker/spec.md)** — specifically
+  **FR-005b** (*"Menstrual cycle preset MUST be modelled as a start/end span … an
+  open span with no Ended is valid"*) and its milestone **M4**, plus the "open
+  Started with no Ended renders as an in-progress span" edge case. That model is
+  exactly what produced the "ongoing forever" bug (rettxweb#231); this ADR replaces
+  it with start + duration.
+
+## Context
+
+Pulse tracks a menstrual period as **two independent point-events** — a `started`
+entry and an `ended` entry — paired heuristically at read time. Both the client
+(rettxweb `pulse-entry-presenter.ts` `deriveMenstrualSpans`/`deriveSpans`,
+`MENSTRUAL_SPAN_CONFIG`) and the server (rettxapi `menstrual_derivation.py`, exposed
+at `GET /v2/patients/{rettxid}/pulse/metrics/menstrual-cycle/cycles`) walk entries
+chronologically and pair a `started` with the next `ended`.
+
+This pairing's failure modes are the **default caregiver behaviour**, not edge cases:
+
+- **Forgetting to log the end** (the norm) leaves a period **`ongoing` forever**. A
+  period from 20 May still rendered "ongoing" on 22 Jul with two newer periods
+  present (rettxweb#231). The mini-calendar painted it as `endDate ?? today`, a solid
+  multi-week block. PR #233 patched this with an "ongoing cap", but that is a
+  band-aid over a structural flaw.
+- **Logging an end with no open start** is **silently dropped** — caregiver input
+  vanishes with no feedback.
+- Logging one period correctly requires **two visits** (start, then remember to
+  return and close it).
+
+The root problem is that the data model can represent **illegal states**: a period
+with no start, and a period that is open forever. "Ongoing" conflates *genuinely in
+progress right now* with *forgot to close it*, and nothing ever closes a stale one.
+
+The `duration`/`count` numeric primitives, the generic entry-form pipeline, and the
+per-field seed-validation contract already exist on both sides — so a
+single-field-per-period model is expressible with the machinery we have.
+
+## Decision
+
+Model a menstrual period as a **single self-contained entry**: a **start date** (the
+entry date) plus a required integer **`duration-days`** (primitive `count`, unit
+days, min 1), with `flow` optional. End date and period length are **derived** from
+the record; cycle length is the gap between consecutive starts. We **remove** the
+`started`/`ended` events, the span pairing, the stored `ongoing` state, and the
+orphan-end handling entirely.
+
+Specifics:
+
+1. **Make illegal states unrepresentable.** Every period has a start (it *is* the
+   entry) and a concrete length. There is no way to record an end without a start,
+   and no period can be open-ended.
+2. **Duration is an integer count of days** using the `count` primitive — *not* the
+   existing `duration` primitive, which is seconds (Seizure uses it). This keeps the
+   stored value honest and human-meaningful.
+3. **Default length = the patient's own trailing average completed-period length,
+   else `DEFAULT_PERIOD_LENGTH_DAYS = 5`**, pre-filled and caregiver-editable. This
+   is an observational display convenience, **not clinical guidance**.
+4. **"In progress" becomes purely presentational** — derived as
+   `start ≈ today && derivedEnd > today` — never a stored open state.
+5. **Reconcile both mental models with one stored field.** The entry form offers a
+   `duration-days` input *and* an optional "it ended on <date>" convenience that
+   computes the duration under the hood. Caregivers who think in "end dates" and
+   those who think in "how many days" both work; only one field is stored.
+6. **Backend-first, contract-owned.** rettxapi owns the seed definition that
+   validates entries, so its seed + derivation change lands and deploys before
+   rettxweb starts sending `duration-days`.
+7. **No migration.** With ~2 pilot testers, the product owner deletes existing
+   menstrual entries; we write no backfill/transform code.
+
+## Consequences
+
+**Positive**
+
+- The rettxweb#231 class of bug is eliminated by construction, not patched. PR #233's
+  ongoing-cap logic is removed as obsolete.
+- One entry logs one period; no second-visit requirement; no silently dropped input.
+- Averages compute from concrete durations only — no null/ongoing pollution.
+- Simpler code on both sides: pairing loops and orphan handling deleted.
+
+**Negative / costs**
+
+- A coordinated **cross-repo change** (rettxapi contract first, then rettxweb),
+  tracked by spec 037 and fanned out as two `squad` issues.
+- i18n churn across **19 locales** (remove started/ended labels, add duration + "in
+  progress"/"ended on" copy).
+- A deliberate one-time **data reset** of pilot menstrual entries.
+- We lose the ability to distinguish a "still bleeding, length unknown" period from a
+  defaulted one — accepted: the caregiver edits duration if it runs long, and the
+  in-progress chip signals recency.
+
+## Alternatives considered
+
+- **Harden the paired-event model** (auto-close stale spans after N days, warn on
+  orphan ends). Rejected: keeps illegal states representable and layers heuristics on
+  a fragile base; PR #233 already showed band-aids accumulate.
+- **Keep `started`/`ended` but make `ended` optional with a stored default end.**
+  Rejected: still two event types, still pairing, still an "open until defaulted"
+  ambiguity.
+- **Reuse the `duration` (seconds) primitive** for the length. Rejected: seconds for
+  a multi-day period is misleading and invites unit bugs; `count` days is honest.
+- **Do a data migration** of existing paired events into duration records. Rejected:
+  disproportionate for ~2 testers; the owner prefers a clean reset.

--- a/site/src/content/docs/decisions/0010-pulse-sleep-entry-duration-quality-model.md
+++ b/site/src/content/docs/decisions/0010-pulse-sleep-entry-duration-quality-model.md
@@ -1,0 +1,153 @@
+---
+title: "ADR 0010 — Pulse sleep entry: total duration + quality, with input-only bedtime/wake"
+description: "Pulse sleep entry: total duration + quality, with input-only bedtime/wake"
+sidebar:
+  order: 11
+---
+
+- **Status**: Proposed (2026-07-22)
+- **Date**: 2026-07-22
+- **Decision-makers**: rettX maintainers
+- **Relates to**: [spec 038](https://github.com/rett-europe/rettx/blob/main/specs/038-pulse-sleep-tracking/spec.md)
+  (rettX Pulse — Sleep Tracking), [spec 035 — rettX Pulse](https://github.com/rett-europe/rettx/blob/main/specs/035-pulse-tracker/spec.md)
+  (the umbrella Pulse tracker this ADR extends with a 6th catalog preset),
+  [ADR 0009](https://github.com/rett-europe/rettx/blob/main/docs/adr/0009-pulse-menstrual-period-duration-model.md) (menstrual period as
+  start + duration — the precedent for "one self-contained entry, one canonical
+  stored field, an input-only convenience for the other mental model"),
+  [ADR 0002](https://github.com/rett-europe/rettx/blob/main/docs/adr/0002-cross-cutting-gap-analysis-pipeline.md) (spec → `spec-fanout`
+  orchestration)
+- **Extends**: the merged umbrella spec **[035 — rettX Pulse](https://github.com/rett-europe/rettx/blob/main/specs/035-pulse-tracker/spec.md)**
+  by adding a sixth catalog preset (`sleep`). It does **not** supersede or weaken any
+  existing 035 requirement.
+
+## Context
+
+rettX Pulse models each metric as a seed preset composed from generic value
+primitives (DURATION, SCALE, COUNT, NOTE, category). The backend (rettxapi
+`app/models/pulse/seed_presets.py` + entry validation in
+`app/services/pulse_services/pulse_tracker_entry_services.py`) is the contract owner:
+it validates every entry field against the seed and 400s an unknown metric or field.
+The client (rettxweb `src/app/core/domain/pulse/seed-presets.ts`) mirrors the seed
+and drives a generic entry form.
+
+Sleep is a recurring caregiver concern in Rett syndrome — fragmented nights, long
+settling times, frequent wakings — but Pulse has no way to record it. Adding sleep
+raises two design questions:
+
+1. **How is the amount of sleep captured and stored?** Caregivers think about sleep
+   in two ways: "they slept about seven and a half hours" (a *duration*) and "they
+   went down at 20:30 and woke at 06:10" (*clock times*). A naive model would store
+   both a bedtime and a wake time — but that reintroduces the class of problem ADR
+   0009 removed for menstrual periods: a record can be left in a **half-entered,
+   illegal state** (bedtime with no wake, or vice versa), and clock times on a
+   date-anchored entry invite cross-midnight and timezone bugs.
+2. **What is Sleep, presentationally?** Unlike seizures or periods (which are counted),
+   the caregiver value in sleep is a **trend** — average hours per night and how it is
+   moving — not a tally.
+
+The primitives needed (DURATION in minutes, SCALE 1–5, COUNT) and the generic
+per-field validation already exist on both sides, so a well-shaped sleep preset is
+expressible with the machinery we have — no new primitive is required.
+
+## Decision
+
+Model a night's sleep as a **single self-contained catalog entry** whose canonical
+amount is one **DURATION** field (`sleep-duration`, minutes), with a **required**
+quality scale and an optional wakings count. **Bedtime and wake-time are an input
+convenience that back-computes the duration and are NOT persisted.**
+
+Specifics:
+
+1. **One entry = one sleep episode (night or nap).** `sleep-duration` (primitive
+   DURATION, unit minutes, REQUIRED, 1–1440) is the single canonical stored amount —
+   the total sleep for that episode. There is no separate stored bedtime or wake time.
+   Because an entry is one episode, multiple entries per date are allowed (a night
+   plus one or more naps); there is no per-day uniqueness constraint.
+2. **Bedtime/wake are input-only.** The form offers an optional bedtime + wake-time
+   pair that computes `sleep-duration` = elapsed minutes (if wake ≤ bedtime, add 24h
+   for cross-midnight). Only the computed duration is stored. Caregivers who think in
+   *durations* and those who think in *clock times* both land on the same one stored
+   field — exactly the two-mental-models / one-field pattern ADR 0009 established with
+   the menstrual "Ended on" convenience.
+3. **Quality is required.** `quality` (primitive SCALE, 1–5, REQUIRED) with Poor↔Great
+   anchors. Pedro flagged quality as core to the metric, so it is not optional. It
+   applies to both night and nap entries.
+4. **Night wakings is optional.** `night-wakings` (primitive COUNT, 0–30, OPTIONAL).
+5. **The night/nap distinction is a 2-option CATEGORY, not a boolean.** `sleep-type`
+   (primitive CATEGORY, options `night` (default) / `nap`) is surfaced as a simple
+   "Nap" tick. Our primitive set has **no boolean**, so a 2-option CATEGORY is the
+   honest mapping. It is **OPTIONAL** in the seed so it can never hard-break an entry,
+   but the app always sends an explicit value; any derivation treats a missing value
+   as `night`. The Duration default is type-dependent (`DEFAULT_SLEEP_MINUTES = 480`
+   for night, `DEFAULT_NAP_MINUTES = 60` for nap).
+6. **Sleep is the first trend metric — and the trend is night-only.** The Metrics-tab
+   card subtitle shows an average *duration* ("avg 7h 40m / night"), not a count; the
+   metric detail shows a nightly-hours trend chart with an avg-hours/night headline
+   plus secondary avg quality and avg wakings. The trend and averages are computed
+   from **NIGHT entries only** so naps don't skew them; naps still appear in the entry
+   history. All aggregation is **client-side** — no new server read/derivation
+   endpoint.
+7. **Composed from existing primitives.** The `sleep` seed introduces **no new
+   primitive**; it is a new preset (`definition_version` 1, `scope=catalog`,
+   `is_seed_preset=True`) assembled from DURATION + SCALE + COUNT + CATEGORY + NOTE.
+   This is the sixth catalog preset.
+8. **Backend-first, contract-owned.** rettxapi owns the seed that validates entries,
+   so the `sleep` seed lands and deploys before rettxweb starts sending the metric
+   (the backend 400s `unknown-metric-code` until then).
+9. **No migration.** A brand-new metric has no existing entries; no backfill code.
+
+## Consequences
+
+**Positive**
+
+- **Illegal states are unrepresentable.** There is no stored "bedtime without wake"
+  half-entry; the canonical amount is always a single well-formed duration.
+- **Consistency with ADR 0009.** Sleep reuses the same "one self-contained entry, one
+  canonical stored field, an optional input-only convenience for the other mental
+  model" shape as the menstrual period, keeping the Pulse model coherent.
+- **Backend stays generic.** No new primitive and no metric-specific server branching;
+  the existing DURATION/SCALE/COUNT/CATEGORY validation enforces the bounds.
+- **No clock-time fields on date-anchored entries.** Cross-midnight and timezone
+  hazards are handled once, at input time on the client, not baked into stored data.
+- **Naps are captured without a new type.** The night/nap distinction rides on an
+  existing CATEGORY primitive, and naps are cleanly excluded from the night-only
+  trend, so nap logging never skews the "avg hours/night" figure.
+- **Trend-first UX.** Averages compute from concrete durations; the caregiver gets the
+  "how are they sleeping lately" answer directly.
+
+**Negative / costs**
+
+- **Exact bedtime/wake clock times are not retained** — only the computed duration. If
+  a future need arises to show or analyse actual bed/wake times, that is a follow-up
+  enhancement (e.g. persisting the pair, or adding a clock-time primitive).
+- **All trend/average computation is client-side**, so any future server-side sleep
+  analytics would need a new derivation endpoint added later.
+- **No dedicated nap summary in v1.** Naps are recorded and listed but get no separate
+  average or chart yet — a possible future enhancement.
+- A coordinated **cross-repo change** (rettxapi seed contract first, then rettxweb),
+  tracked by spec 038 and fanned out as two `squad` issues.
+- i18n across **19 locales** for the new sleep strings (label, field labels, quality
+  anchors, bedtime/wake labels, hour/minute units, "avg / night", "{n} wakings", and
+  Sleep type / Night / Nap).
+- Adds a **sixth catalog preset** to the umbrella Pulse spec (relates to spec 035).
+
+## Alternatives considered
+
+- **Store bedtime and wake time as two persisted fields.** Rejected: reintroduces the
+  half-entered illegal state ADR 0009 eliminated, puts clock times on date-anchored
+  entries (cross-midnight/timezone hazards), and complicates aggregation — trends want
+  a duration, not two timestamps.
+- **Make quality optional.** Rejected: Pedro flagged quality as core; an optional
+  quality would leave many nights with only a duration and no sense of how the night
+  went, undermining the metric's purpose.
+- **Add a new "sleep" primitive.** Rejected: unnecessary — DURATION (minutes) + SCALE
+  + COUNT + CATEGORY already express the whole shape; a new primitive would add
+  backend surface for no gain.
+- **Model the nap flag as a boolean.** Rejected: the primitive set has no boolean
+  primitive. A 2-option CATEGORY (`night`/`nap`) is the honest mapping and keeps the
+  door open to more sleep types later without a schema change.
+- **Add a server-side sleep trend/derivation endpoint now.** Rejected as premature:
+  the client can compute nightly-hours averages from the entries it already reads; a
+  server endpoint can be added later if cross-surface analytics need it.
+- **Fold naps into the nightly average.** Rejected: naps would skew "avg hours/night".
+  Naps are captured but excluded from the night-only trend.

--- a/site/src/content/docs/decisions/index.md
+++ b/site/src/content/docs/decisions/index.md
@@ -18,6 +18,13 @@ in the source tree.
 
 | # | Title | Status |
 |---|---|---|
-| [0001](https://github.com/rett-europe/rettx/blob/main/docs/adr/0001-control-plane-repo.md) | Establish a control-plane repository for rettX | Accepted |
-
-More to come as the program matures.
+| [0001](/decisions/0001-control-plane-repo/) | rettx is the rettX control-plane repo | Accepted |
+| [0002](/decisions/0002-cross-cutting-gap-analysis-pipeline/) | Gap-analysis-first pipeline for cross-cutting work | Accepted |
+| [0003](/decisions/0003-message-channel-content-model/) | In-app vs email content model for the Message Center | Accepted |
+| [0004](/decisions/0004-message-center-no-historical-backfill/) | Message Center launches with no historical backfill | Accepted |
+| [0005](/decisions/0005-message-center-rollout-pilot-then-default-on/) | Message Center rollout: per-user pilot, then default-on for all | Accepted — implemented 2026-06-25 |
+| [0006](/decisions/0006-message-center-template-store-layout/) | Message Center template store: multi-channel layout & naming | Accepted (2026-07-11) |
+| [0007](/decisions/0007-ai-code-review-custom-instructions/) | AI code-review custom instructions across the ecosystem | Accepted (2026-07-11) |
+| [0008](/decisions/0008-retire-autonomous-squad-agent-system/) | Retire the autonomous Squad/Ralph agent system | Accepted (2026-07-11) |
+| [0009](/decisions/0009-pulse-menstrual-period-duration-model/) | Pulse menstrual period modelled as start + duration | Proposed (2026-07-22) |
+| [0010](/decisions/0010-pulse-sleep-entry-duration-quality-model/) | Pulse sleep entry: total duration + quality, with input-only bedtime/wake | Proposed (2026-07-22) |


### PR DESCRIPTION
## Problem / root cause

The docs site's **Decisions (ADRs)** section is generated by Starlight from `site/src/content/docs/decisions/`, which previously contained **only `index.md`**. That index had a hand-maintained table listing just **ADR 0001**. Meanwhile `docs/adr/` holds the real ADRs (now **10**: `0001` … `0010`). None of them past 0001 were ever published, and the hand-maintained table silently drifted from reality.

## Fix

Add a build-time sync script, `scripts/sync-adrs.mjs` (pure Node ESM, **no external dependencies** — `node:fs` / `node:path` only), that treats `docs/adr/` as the **single source of truth** and generates a Starlight view from it:

- For every `*.md` in `docs/adr/`, emit a page under `site/src/content/docs/decisions/<same-filename>` with:
  - YAML frontmatter (`title`, `description`, `sidebar.order = ADR number + 1`) using safely double-quoted strings.
  - The source body with the duplicate H1 removed (Starlight renders the title from frontmatter).
  - Relative markdown links rewritten to absolute `https://github.com/rett-europe/rettx/blob/main/…` URLs (sibling ADRs, `../../specs/…`, `.specify/memory/…`), so they resolve on the site. Absolute / anchor-only / `mailto:` links are left untouched; trailing `#anchors` are preserved.
- Regenerate the `## Currently merged ADRs` table in `index.md` from the same source: one row per ADR (`| # | Title | Status |`), the `#` cell linking to the in-site route `/decisions/<slug>/`, with the parsed **Status** (e.g. `Accepted`, `Accepted — implemented 2026-06-25`, `Proposed (2026-07-22)`). The frontmatter + intro prose above the heading are preserved verbatim.

The script is **idempotent** (re-running yields byte-identical output).

## Never drift again

Wired into the site build in `site/package.json` so CI (`docs-deploy.yml` runs `npm run build` with `working-directory: site`) always regenerates before building:

- `"sync:adrs": "node ../scripts/sync-adrs.mjs"`
- `"build": "node ../scripts/sync-adrs.mjs && astro check && astro build"`
- `"dev": "node ../scripts/sync-adrs.mjs && astro dev"`

## Validation

From `site/`: `npm ci` then `npm run build` — **passes**. `astro check` reports **0 errors, 0 warnings, 0 hints**; `astro build` builds all 10 ADR pages plus `index.md`, and the regenerated index table lists all 10 ADRs with correct statuses.

## Note

`docs/adr/` **remains the single source of truth**. The pages under `site/src/content/docs/decisions/` are a generated view; edit the ADRs in `docs/adr/` and the site follows automatically.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>