### PR TITLE
spec(039): flip status ready to trigger fanout

### DIFF
--- a/specs/039-pulse-admin-insights/spec.md
+++ b/specs/039-pulse-admin-insights/spec.md
@@ -9,7 +9,7 @@
 spec_id: "039"
 slug: "pulse-admin-insights"
 title: "rettX Pulse — Admin patient overview & pilot insights"
-status: draft   # draft | ready | accepted | superseded
+status: ready   # draft | ready | accepted | superseded
 authored: "2026-07-24"
 author: "perocha"
 source_issue: "rett-europe/rettx#41"


### PR DESCRIPTION
Flips spec 039 to `ready` so the spec-fanout workflow opens the rettxapi + rettxadmin squad issues on merge.