### PR TITLE
docs(spec): 041 — multi-caregiver patient sharing (Pulse contributors)

### DIFF
--- a/.specify/memory/patterns.md
+++ b/.specify/memory/patterns.md
@@ -116,9 +116,33 @@ are coordinated through a cross-cutting spec.
   persistence and uniqueness enforcement live in `rettxapi`.
 - **ConsentDocument** — a versioned legal artefact that the caregiver has
   accepted; acceptance is recorded with timestamp and actor.
+  - **Pulse Contribution Consent** — a ConsentDocument *subtype*, distinct from
+    the patient-creation consent and scoped to **contributing Pulse
+    observations** to an existing patient. Accepted by a Pulse contributor at
+    invite acceptance; its `consent_document_id` + `version` + `accepted_at` are
+    recorded on the `patient_access` grant. Introduced by
+    [spec 041](../../specs/041-multi-caregiver-sharing/spec.md).
 - **File** — uploaded artefact (e.g. genetic report, medical document)
   living in segregated blob containers.
 - **Permission level** — `owner`, `edit`, `read`. Server-enforced.
+  - **`pulse`** — a **narrow contributor scope** (not a rung on the
+    read/edit ladder): it permits **creating Pulse entries** and a **minimal
+    read** (patient display name/nickname + the Pulse tracker & history) and
+    **nothing else** — no genetic data, documents, medical profile, or
+    patient-info edit, and it does **not** imply general `read`. Enforced
+    server-side by its own dependency (e.g. `require_patient_pulse_write`). See
+    [ADR 0011](../../docs/adr/0011-pulse-contributor-access-scope.md) and
+    [spec 041](../../specs/041-multi-caregiver-sharing/spec.md).
+- **Pulse contributor** — a principal holding the `pulse` scope on a patient:
+  a person the **owner** invited to help log Pulse. Not a co-owner/steward —
+  the patient **owner** (creator) remains the sole administrator (v1).
+- **Invite** — a pending, consent-gated offer to grant access to a patient by
+  email, with a single-use token (hashed at rest) and expiry. Lifecycle states:
+  `pending → accepted | declined | expired | cancelled`; the resulting
+  `patient_access` grant is then `active` until `revoked`. Privacy-first: nothing
+  identifying is revealed before acceptance and the accepting identity's verified
+  email must match the invited address. Introduced by
+  [spec 041](../../specs/041-multi-caregiver-sharing/spec.md).
 
 If a term means different things in different repos, that is a defect to
 be reconciled, not a feature.
@@ -347,3 +371,4 @@ GitHub docs on
 | 2026-07-11 | §1/§5: renamed the Message Center template folder `emails/` → **`messages/`** ([ADR 0006](../../docs/adr/0006-message-center-template-store-layout.md), Accepted) since it now carries email + in-app + push content; documented the per-channel file-suffix convention. Deploy strips the folder prefix, so the blob container stays `email-templates` and `rettxapi` is unaffected. |
 | 2026-07-11 | Added §10 **AI-assisted code review & custom instructions** ([ADR 0007](../../docs/adr/0007-ai-code-review-custom-instructions.md)): every repo must maintain a review-focused `.github/copilot-instructions.md`; path-specific rules go in `.github/instructions/*.instructions.md` with `applyTo:` frontmatter (never in the repo-wide file); files stay concise and enforce the cross-cutting non-negotiables (PHI, auth, i18n, contract ownership, test integrity). Renumbered the change log to §11. Prompted by an audit showing all repos have the file but content was uneven/agent-oriented (e.g. `rettxweb` thin, `rettxapi` with a stray `applyTo:` in the repo-wide file). |
 | 2026-07-11 | §6: retired the autonomous **Squad/Ralph** toolkit (the `squad-*.yml` workflows and `.squad/` directories) across the downstream repos. The `squad` label is **retained** as the fan-out inbox marker, now picked up by a human/orchestrated working session rather than an automated agent. See [ADR 0008](../../docs/adr/0008-retire-autonomous-squad-agent-system.md). |
+| 2026-07-26 | §2: added the narrow **`pulse`** contributor permission scope (create Pulse + minimal read only; server-enforced; does not imply general `read`), the **Pulse contributor** and **Invite** (with lifecycle states) vocabulary, and the **Pulse Contribution Consent** ConsentDocument subtype. Prompted by [spec 041](../../specs/041-multi-caregiver-sharing/spec.md) and [ADR 0011](../../docs/adr/0011-pulse-contributor-access-scope.md) (multi-caregiver Pulse contribution: single owner + narrow `pulse` scope). |

--- a/docs/adr/0011-pulse-contributor-access-scope.md
+++ b/docs/adr/0011-pulse-contributor-access-scope.md
@@ -47,6 +47,20 @@ patient info); `read` is both too broad (whole record) and too narrow (no
 write). No existing level fits, and per constitution **VI** the restriction MUST
 be enforced server-side — UI gating is not a security control.
 
+**Identity/provisioning constraint (verified in `rettxapi`).** rettX cannot
+store a person without a pre-existing Auth0 identity. `Principal`
+(`app/models/principal/principal_models.py`) requires `identities` with
+`min_length=1` and a mandatory Auth0 `sub` per identity; principals are created
+**only** by JIT provisioning on first authenticated login
+(`app/routers/users.py` `/user/profile` →
+`PrincipalProfileServices.ensure_principal_for_user`); `patient_access`
+`grant_access` calls `_validate_principal_exists` and 404s without an existing
+`principal_id` (no grant-by-email, no pending grant); and the Auth0 client
+(`app/authentication/auth0_client.py`) has **no `create_user`**. So any "invite a
+new person" design must either restrict invites to already-registered users or
+provision the invitee through the existing self-signup + JIT path — rettxapi
+cannot mint Auth0 accounts.
+
 ## Decision
 
 Introduce a **new, narrow, server-enforced `pulse` permission scope** in the
@@ -74,10 +88,20 @@ and keep the surrounding sharing model minimal.
    `accepted_at`, `principal_id`) is recorded on the grant. The full lifecycle,
    states, and safeguards live in
    [spec 041](../../specs/041-multi-caregiver-sharing/spec.md).
+4. **Model B — invite any email, provision-on-accept.** Given the
+   identity/provisioning constraint above, invites are **not** restricted to
+   already-registered users. The owner (or admin) issues a pending, **email-keyed
+   Invitation**; if the invitee has no account they **self-register through the
+   existing Auth0 signup** (which mints the Auth0 identity) and their Principal is
+   **JIT-provisioned** on first login. Accepting then **resolves the invitation
+   into the `pulse` grant**, gated by the **verified-email-match** against
+   `invited_email`. Deliberate boundary: **no rettxapi-side Auth0 user
+   creation** and **no change to the `Principal` model** — the auth surface stays
+   minimal and reuses the trusted signup + JIT path already in production.
 
 This ADR owns the **architectural** decision (a new access scope + the
-single-owner boundary); spec 041 owns the feature detail and the cross-repo
-fan-out.
+single-owner boundary + the Model B provisioning approach); spec 041 owns the
+feature detail and the cross-repo fan-out.
 
 ## Consequences
 
@@ -126,3 +150,9 @@ fan-out.
   over-engineering for a single capability today; if more scoped-sharing needs
   emerge, that generalisation can be its own ADR building on the `pulse`
   precedent.
+- **Invite existing (already-registered) users only** vs **invite any email**
+  (Model B). Rejected the existing-only option: most family members and carers
+  will not be pre-registered, so restricting invites to known principals would
+  make the feature largely unusable. Model B invites any email and provisions the
+  invitee through the existing Auth0 self-signup + JIT path on accept, which
+  needs no new Auth0 user-creation capability in rettxapi.

--- a/docs/adr/0011-pulse-contributor-access-scope.md
+++ b/docs/adr/0011-pulse-contributor-access-scope.md
@@ -1,0 +1,128 @@
+# ADR 0011 — Narrow `pulse` contributor scope for multi-caregiver Pulse contribution
+
+- **Status**: Proposed (2026-07-26)
+- **Date**: 2026-07-26
+- **Decision-makers**: rettX maintainers
+- **Relates to**: [spec 041 — Patient Sharing: Pulse Contributors](../../specs/041-multi-caregiver-sharing/spec.md)
+  (the cross-cutting spec this ADR anchors),
+  [spec 035 — rettX Pulse](../../specs/035-pulse-tracker/spec.md) (the umbrella
+  Pulse tracker whose entries contributors write),
+  [`patterns.md` §2](../../.specify/memory/patterns.md) (shared vocabulary /
+  permission levels) and [§4](../../.specify/memory/patterns.md) (server-side
+  authorization), [program constitution](../../.specify/memory/constitution.md)
+  principles **I** (caregivers first), **II** (privacy by design) and **VI**
+  (security baseline)
+
+## Context
+
+A patient owner should be able to let a second person — a partner, relative, or
+carer — help **log Pulse** for their patient, which is especially valuable for
+day-to-day Pulse tracking. The two hard constraints are **consent** and
+**privacy** (constitution I/II).
+
+The data layer can already **represent** this. In `rettxapi` the `patient_access`
+container holds multiple grants per patient, keyed by `principal_id`, with
+active-only filters (`include_revoked` / `include_deleted`) and a
+`query_by_principal_id` lookup. Access resolves into a
+`ResolvedPatientAccessContext` and is enforced server-side by the dependencies
+`require_patient_read_access_v2` (READONLY+) and `require_patient_write_access_v2`
+(EDIT+). What is **missing** is any mechanism to *create* a share, and there is
+no consent step for a person added to an *existing* patient (consent is captured
+only at patient creation, by the creator).
+
+The product decision (Pedro, 2026-07-25) is to keep v1 **deliberately small**:
+one **owner** (the creator) stays the sole administrator, and the people they add
+can do exactly one thing — **contribute Pulse entries**. They must **not** be
+able to edit patient information or see the clinical record (genetic data,
+documents, medical profile). The broader "co-caregiver" idea (a second steward
+with read/edit of the whole record who can invite others) is **out of scope for
+v1**; complex custody situations (e.g. divorced / dual-equal parents) are
+accepted as corner cases to revisit later.
+
+The problem is that the existing permission ladder — `owner`, `edit`, `read`
+([`patterns.md` §2](../../.specify/memory/patterns.md)) — cannot express
+"may create Pulse entries **but** may not edit the patient **and** may not read
+the clinical record". `edit` is too broad (it grants full write, including
+patient info); `read` is both too broad (whole record) and too narrow (no
+write). No existing level fits, and per constitution **VI** the restriction MUST
+be enforced server-side — UI gating is not a security control.
+
+## Decision
+
+Introduce a **new, narrow, server-enforced `pulse` permission scope** in the
+`patient_access` model as the mechanism for multi-caregiver Pulse contribution,
+and keep the surrounding sharing model minimal.
+
+1. **New `pulse` scope.** Distinct from `owner` / `edit` / `read`, the `pulse`
+   scope permits **creating Pulse entries** and a **minimal read** — the patient
+   display name / nickname and the Pulse tracker & history — and **nothing
+   else**. It grants no access to genetic data, uploaded documents, or the
+   medical profile, and no ability to edit patient information. It is **not** a
+   rung on the read/edit ladder (it does not imply general `read`); it is a
+   capability scope enforced by its own dependency, e.g.
+   `require_patient_pulse_write`. Pulse-write endpoints accept it; every other
+   read/write endpoint rejects it.
+2. **Single owner, no co-caregiver in v1.** The patient **owner** (creator)
+   remains the sole administrator. A `pulse` contributor cannot invite or revoke
+   anyone, cannot see a co-contributor management view, and cannot edit the
+   patient. Ownership transfer and multi-owner custody are out of scope for v1.
+3. **Consent-gated, privacy-first onboarding.** A `pulse` grant is created only
+   through an invite with **double opt-in** — nothing identifying is revealed
+   before acceptance, the accepting identity's **verified email must match** the
+   invited address, and the invitee must accept a distinct, versioned **Pulse
+   Contribution Consent** whose acceptance (`consent_document_id`, `version`,
+   `accepted_at`, `principal_id`) is recorded on the grant. The full lifecycle,
+   states, and safeguards live in
+   [spec 041](../../specs/041-multi-caregiver-sharing/spec.md).
+
+This ADR owns the **architectural** decision (a new access scope + the
+single-owner boundary); spec 041 owns the feature detail and the cross-repo
+fan-out.
+
+## Consequences
+
+**Positive**
+
+- **Least privilege by construction** (constitution II): a contributor can never
+  reach the clinical record, so a mis-share leaks far less than a general
+  read/edit grant would. Privacy is enforced by the scope, not by UI hiding.
+- **Server-side enforcement** (constitution VI): the `require_patient_pulse_write`
+  dependency makes "Pulse only" a real trust boundary, consistent with the
+  existing `require_*_access_v2` pattern.
+- **Small surface area**: no co-caregiver management, no role picker, fewer
+  states and fewer consent questions — the smallest change that delivers the
+  Pulse-help value.
+- Reuses the existing multi-grant `patient_access` machinery; the net-new
+  backend piece is one scope + one guard.
+
+**Negative / costs**
+
+- A **new access level** is a shared-vocabulary change: `patterns.md` §2 must
+  record `pulse`, and every surface/endpoint author must understand that it does
+  **not** imply general `read`.
+- Each patient-data endpoint must be reviewed to ensure it correctly **rejects**
+  the `pulse` scope; a missed endpoint is a privacy regression.
+- The narrow scope does **not** cover legitimate future needs (a genuine second
+  steward, shared editing, contributor-managed invites); those will need a
+  follow-up decision rather than a quick widening of `pulse`.
+- Custody corner cases (dual-equal parents) remain unserved in v1 — an accepted,
+  documented limitation.
+
+## Alternatives considered
+
+- **Reuse the existing `edit` level for contributors** and hide non-Pulse
+  surfaces in the client. Rejected: `edit` grants full patient-info write and
+  clinical read; UI hiding is not a security control (constitution VI), so a
+  contributor could edit clinical data or read the whole record via the API.
+  Fails least-privilege and privacy.
+- **A full "co-caregiver" role** (a second steward with read/edit of the whole
+  record, able to invite others and see co-caregivers). Rejected for v1: a much
+  larger consent and privacy surface, more invite/grant states, owner-vs-member
+  ambiguity, and transitive-invite sprawl — disproportionate to the actual need,
+  which is "help me log Pulse". Deferred, not discarded.
+- **Client-side-only gating** of a Pulse-only experience over an `edit` grant.
+  Rejected outright: not a server-side control (constitution VI).
+- **A generic per-feature ACL / scoped-permission framework.** Rejected as
+  over-engineering for a single capability today; if more scoped-sharing needs
+  emerge, that generalisation can be its own ADR building on the `pulse`
+  precedent.

--- a/specs/041-multi-caregiver-sharing/research.md
+++ b/specs/041-multi-caregiver-sharing/research.md
@@ -1,0 +1,263 @@
+# Multi-Caregiver Sharing — Design Options & Brainstorm (research for spec 041)
+
+**Status:** design record / research backing `spec.md` in this folder.
+**Repo context:** `rett-europe/rettx` control plane. No downstream repo edits.
+**Author:** perocha · **Date:** 2026-07-25
+
+---
+
+## 0. Problem statement
+
+A patient in rettX should be shareable with **2+ caregivers** who can view (and
+potentially update) the same patient record — especially valuable for **Pulse**.
+The two design constraints that dominate everything below are **CONSENT** and
+**PRIVACY**, per constitution principles I (caregivers first), II (privacy by
+design), III (transparency).
+
+### Ground truth (already verified in the `rettxapi` codebase — do not re-derive)
+
+- The data model **already** supports multiple access grants per patient:
+  a `patient_access` container holds grants keyed by `principal_id`, with
+  active-only filters (`include_revoked` / `include_deleted`) and a
+  `query_by_principal_id` lookup.
+- Access resolves into a `ResolvedPatientAccessContext` (`principal_id` +
+  `patient_id`) and is enforced server-side by dependencies:
+  `require_patient_read_access_v2` (READONLY+) and
+  `require_patient_write_access_v2` (EDIT+).
+- **So multi-caregiver access is REPRESENTABLE today.**
+- **Missing:** any mechanism — caregiver-facing *or* admin-facing — to actually
+  **create a share** (add a second caregiver to an existing patient).
+- **Consent gap:** consent is captured only at patient **creation**, by the
+  creating caregiver. There is **no** consent step for a *second* caregiver
+  added to an existing patient.
+
+### Permission levels (patterns.md §2)
+
+`owner`, `edit`, `read` — server-enforced. Seed facts confirm READONLY+ and
+EDIT+ dependency gates. The **owner** is the record's steward (creator).
+
+---
+
+## 1. Design dimensions — options, trade-offs, recommendation
+
+### (a) Initiation model — who can start a share?
+
+| Option | Description | Trade-offs |
+|---|---|---|
+| A1 Caregiver-initiated | Owner invites another caregiver by email | Self-service, low burden (Principle I); owner controls their own record |
+| A2 Admin-initiated | Registry admin grants access | Useful for support/edge cases; heavier, less patient-empowering; risk of paternalism |
+| A3 Both | Caregiver primary + admin as support path | Most complete; more surface area |
+
+**Recommendation: A3 (both), phased.** Caregiver-initiated invite is the P1
+primary path (aligns with Principle I: caregivers own their data, minimal
+burden). Admin-initiated grant is a P2/P3 support path with stricter audit.
+**Crucially, neither path may bypass invitee consent** — admin cannot silently
+add a caregiver; the double-opt-in below still applies.
+
+### (b) Invite / accept lifecycle & states
+
+Proposed states (single invite object):
+
+```
+                cancel / resend
+                     │
+ (create) ──▶ PENDING ──▶ ACCEPTED ──▶ (grant becomes ACTIVE)
+                │  │  └────▶ DECLINED
+                │  └───────▶ EXPIRED
+                └──────────▶ CANCELLED   (owner/admin withdrew before accept)
+
+ ACTIVE grant ──▶ REVOKED   (owner/admin/self withdraws after accept)
+```
+
+- **Invitee has no account:** invite links into an Auth0 sign-up path; after
+  sign-up + email verification they land in the review/consent step.
+- **Invitee already has an account:** authenticate, then review/consent.
+- **Wrong-email safeguard (double opt-in):** the invite reveals **nothing
+  identifying** pre-acceptance (see (e)). Invitee must authenticate with an
+  identity whose **verified email matches** the invited email, then review and
+  **accept the shared-access consent**, and only THEN is the grant activated and
+  patient identity revealed.
+- **Token:** single-use, **hashed at rest**, time-boxed expiry (default **7
+  days**, OPEN), resend + cancel supported, rate-limited.
+
+**Recommendation:** adopt the state machine above; make the invite object the
+source of truth for lifecycle, and the `patient_access` grant the source of
+truth for *active access* (created only on acceptance).
+
+### (c) Consent model for the secondary caregiver
+
+| Option | Description | Trade-offs |
+|---|---|---|
+| C1 Reuse creation consent | Secondary accepts same artifact the creator did | Simple; but semantics differ — they are not the creator/owner |
+| C2 Distinct shared-access consent | New versioned `ConsentDocument` for joining an existing patient | Clear lawful basis; matches their actual role; small extra authoring |
+| C3 Hybrid | Creation consent + shared-access addendum | Most explicit; more artifacts to maintain |
+
+**Recommendation: C2 — a distinct, versioned "Shared-Access Consent"
+`ConsentDocument`.** Rationale: the secondary caregiver's relationship and
+lawful basis differ from the creator's (they are accepting to view/handle
+special-category data about **someone else's** patient). Per Principle II
+(purpose limitation, informed consent, withdrawable):
+
+- The **accepted-consent record lives on the `patient_access` grant**:
+  `consent_document_id` + `version` + `accepted_at` + `principal_id`.
+- **Re-consent** required on a material policy/version change.
+- **Withdrawal** = the caregiver revokes their own grant (consent is
+  withdrawable at any time).
+- Consent artifact is authored in the **`templates`** repo (per patterns §1,
+  consent forms live there).
+
+### (d) Roles / permissions of a secondary caregiver
+
+- **Default = `read` (least privilege).** Inviter selects `read` or `edit` at
+  invite time. (OPEN: default view-only vs edit — question for Pedro.)
+- **Owner stays singular** (the creator). Secondary caregivers are **members**,
+  not owners → clear "owner vs member" distinction.
+- **v1: only the owner (and admin) can invite or revoke** others — avoids
+  transitive sprawl and consent-chain ambiguity.
+- **Pulse read/write** follows the grant level (`edit` → can log Pulse entries).
+- **Delete patient:** owner only.
+- **Can members see co-caregivers?** Recommend: members can see that
+  co-caregivers exist + display name + role (needed for coordination and to make
+  shared-edit attribution meaningful). **OPEN — privacy trade-off for Pedro.**
+
+### (e) Privacy / security safeguards
+
+- **Pre-accept data minimization (Principle II):** to an unverified/incorrect
+  recipient, reveal **nothing identifying** — no patient name, no rettX ID, no
+  diagnosis. The invite says only something like *"A caregiver has invited you to
+  help care for a patient on rettX."* (OPEN: may we show the **inviter's** first
+  name? That is itself a small disclosure — question for Pedro.)
+- **Email verification / match:** grant activates only when the authenticated
+  identity's verified email matches the invited address.
+- **Invite expiry** + **rate limiting** on invite creation and accept attempts.
+- **Notify existing caregiver(s)** when an invite is sent and when someone joins
+  (transparency + anti-mis-share signal).
+- **GDPR interplay:** the **data subject is the patient**, not the caregiver.
+  Distinguish (i) erasure of a caregiver's *account* from (ii) the patient's
+  right to erasure. A revoked caregiver's *authored* patient data (e.g. Pulse
+  entries) is the **patient's** data — provenance must be preserved (Principle
+  IV); pseudonymize the actor only on account erasure. **OPEN — legal input.**
+- **Full audit trail** for invite create/resend/cancel/accept/decline/expire and
+  grant activate/revoke (Principle VI: auditable).
+
+### (f) Attribution & audit for shared edits
+
+- Every Pulse (and other) entry is attributed to the **acting `principal_id`**.
+- History is **visible** (who logged what, when) — Principle IV: data provenance
+  preserved (who entered, when, against what schema version).
+- Audit records are immutable; correlation uses opaque identifiers (Principle
+  VI: no PII in logs).
+
+### (g) Revocation & offboarding
+
+- **Who can revoke whom:** owner revokes any member; admin can revoke anyone;
+  a member can **self-revoke** (= withdraw consent). Owner cannot be revoked
+  (only account/ownership transfer, out of scope v1).
+- On revoke: grant flagged `revoked` (soft-delete — the existing
+  `include_revoked` filter already supports this). Access ceases immediately.
+- **Authored data stays** (patient's data; provenance preserved). Attribution
+  retained unless/until actor account erasure. **OPEN — confirm policy.**
+
+### (h) Admin tooling (`rettxadmin`, Entra ID)
+
+- **Visibility:** list every principal who can access a patient (incl. revoked),
+  with role + consent status + accepted-at.
+- **Grant/revoke:** admin-initiated grant (still requires invitee consent
+  double-opt-in) and admin revoke.
+- **Audit:** admin view of the full invite/grant audit trail.
+
+---
+
+## 2. Cross-repo impact map (for a FUTURE spec-fanout — do NOT implement here)
+
+| Repo | Slice |
+|---|---|
+| **rettxapi** (contract owner) | New invite/share endpoints (create, list, accept, decline, cancel, resend, revoke, list co-caregivers); invite entity/container with state machine + hashed token + expiry; extend `patient_access` grant with role + accepted-consent record + invite linkage; reuse existing `require_*_access_v2` deps; audit events; trigger message sends. |
+| **rettxweb** (Auth0, Capacitor native) | Caregiver UI: invite-a-caregiver (email + role), pending-invites list, accept-invite flow (authenticate → review → accept shared-access consent), co-caregiver list, revoke, notifications. Native push nudge for invite/join (FCM device token path). |
+| **rettxadmin** (Entra ID) | Admin view of patient access grants, admin grant/revoke, admin audit view. |
+| **templates** | New Message Center templates (email + in-app + push, per-locale): invite, "you've been added", "someone joined your patient". New **Shared-Access Consent** `ConsentDocument`. Any Auth0 sign-up email template changes. |
+| **rettxid** | **Likely none.** Pseudonymous ID unchanged; invite tokens are NOT rettX IDs. *Confirm no impact.* |
+
+---
+
+## 3. Proposed `patterns.md` extensions (propose, don't invent ad hoc)
+
+- **Shared vocabulary additions:** *Share / Access Grant*, *Invite*,
+  *Co-caregiver (secondary caregiver)*, *Owner vs Member* distinction.
+- **Invite state vocabulary:** `pending | accepted | declined | expired |
+  cancelled` (invite) and `active | revoked` (grant).
+- **ConsentDocument subtype:** *Shared-Access Consent* (distinct from creation
+  consent), versioned.
+
+(No new routing labels appear necessary.)
+
+---
+
+## 4. Constitution Check (highlights)
+
+- **I (caregivers first):** self-service invite, minimal-burden flow, withdrawal
+  anytime, no dark patterns. ✅
+- **II (privacy by design):** pre-accept minimization, distinct withdrawable
+  consent, purpose limitation, EU/GDPR data-subject handling, audit. ✅
+- **III (transparency):** ships with an ADR + patient-readable docs on the
+  sharing/consent model. ✅
+- **IV (accuracy/accountability):** shared-edit provenance/attribution
+  preserved. ✅
+- **VI (security):** server-side authz (already), hashed single-use tokens,
+  rate limiting, full audit. ✅
+
+---
+
+## 5. RECOMMENDED approach (one-paragraph summary)
+
+Caregiver-initiated, email-based **invite with double opt-in**: owner invites by
+email + chooses role (default `read`); recipient sees **nothing identifying**
+until they authenticate with a **matching verified email** and **accept a
+distinct, versioned Shared-Access Consent**, at which point a `patient_access`
+grant is activated (carrying the consent record). Admin has a parallel
+grant/revoke + visibility path that **also** honours consent. All lifecycle
+events are audited; shared edits are attributed to the acting principal;
+revocation is soft and preserves patient-data provenance.
+
+---
+
+## 6. OPEN DECISIONS for Pedro (product / legal)
+
+**Highest-leverage — DECIDED by Pedro (2026-07-25):**
+1. **Initiation:** ✅ **Both** — caregiver self-service is primary, admin as a
+   support path (both honour consent).
+2. **Wrong-email tolerance / pre-accept disclosure:** ✅ **Strictest** — reveal
+   nothing identifying pre-acceptance; require verified email-match to activate.
+3. **Default role:** ✅ **Read-only default; inviter selects `read` or `edit`**
+   at invite time.
+4. **Consent artifact:** ✅ **New distinct, versioned Shared-Access Consent**,
+   recorded on the `patient_access` grant.
+
+### PIVOT — simplified model (Pedro, 2026-07-25)
+
+Pedro chose to **radically constrain complexity** and the spec was rewritten
+around it (see `specs/041-multi-caregiver-sharing/spec.md`):
+
+- **Single owner** (the patient creator) is the *only* administrator. No
+  "co-caregiver" concept; no owner-vs-member logic; contributors cannot invite
+  or revoke others.
+- Invitees become **Pulse contributors**: they can **only create Pulse
+  entries**. They **cannot** edit patient info.
+- **Read scope is minimal**: a contributor sees only the patient display
+  name/nickname + the Pulse tracker & history — **no** genetic data, documents,
+  or medical profile. (Even stronger Principle II data minimization.)
+- Supersedes decision #3 (no `read`/`edit` picker — role is the fixed
+  Pulse-contributor scope). Consent (#4) narrows to a **Pulse Contribution
+  Consent**.
+- Backend note: the Pulse-write-but-not-patient-edit restriction needs a **new
+  narrow server-side scope** (e.g. `pulse`/`contribute`), enforced server-side
+  (Principle VI) — not a reuse of `edit`.
+- Corner cases (e.g. divorced / dual-equal parents) are **out of scope for v1**.
+
+**Secondary (decide before spec `ready`):**
+- Can members see co-caregivers' identities/roles?
+- Can members (not just owner) invite/revoke others?
+- Erasure/attribution policy for a revoked caregiver's authored Pulse data.
+- Invite expiry duration (default 7 days?).
+- Notify-all-caregivers-on-join policy.
+- Confirm `rettxid` has no impact.

--- a/specs/041-multi-caregiver-sharing/spec.md
+++ b/specs/041-multi-caregiver-sharing/spec.md
@@ -384,8 +384,10 @@ Pulse-contributor grant (still consent-gated), revoke, and read the audit trail.
 - **II — Privacy by design (NON-NEGOTIABLE)**: strict pre-accept minimization,
   narrow `pulse` scope (contributors never see the clinical record), distinct
   withdrawable consent, purpose limitation, verified email-match, audit. ✅✅
-- **III — Transparency (NON-NEGOTIABLE)**: pair with an ADR and patient-readable
-  docs on the sharing/consent model before `ready`. ⚠️ *(ADR to be authored.)*
+- **III — Transparency (NON-NEGOTIABLE)**: the architectural decision (new
+  `pulse` scope + single-owner boundary) is recorded in
+  [ADR 0011](../../docs/adr/0011-pulse-contributor-access-scope.md);
+  patient-readable docs to follow on the public site before launch. ✅
 - **IV — Accuracy/accountability**: Pulse-entry provenance/attribution
   preserved. ✅
 - **VI — Security baseline**: server-side enforcement of the narrow `pulse`
@@ -408,13 +410,16 @@ Pulse-contributor grant (still consent-gated), revoke, and read the audit trail.
 - **`rettxid` is not affected**; invite tokens are not rettX IDs.
 - Default invite expiry is **7 days**.
 
-## Proposed patterns.md extensions (do not invent ad hoc)
+## patterns.md extensions (applied)
 
-- **Permission-level vocabulary**: add a narrow **`pulse`** (contribute) scope
-  below `edit` (current levels are `owner | edit | read`), defined as
-  Pulse-create + minimal Pulse read only.
-- **Vocabulary**: *Pulse contributor* (a principal holding the `pulse` scope on
-  a patient), *Invite*, and the single-**owner** stewardship model.
+These were **applied** to [`.specify/memory/patterns.md`](../../.specify/memory/patterns.md)
+§2 on 2026-07-26 (see its §11 change log):
+
+- **Permission level**: added the narrow **`pulse`** scope — *not* a rung on the
+  read/edit ladder (does not imply general `read`); Pulse-create + minimal Pulse
+  read only, server-enforced.
+- **Vocabulary**: *Pulse contributor* (a principal holding the `pulse` scope),
+  *Invite* (with lifecycle states), and the single-**owner** stewardship model.
 - **Invite state vocabulary**: `pending | accepted | declined | expired |
   cancelled` (invite) and `active | revoked` (grant).
 - **ConsentDocument subtype**: *Pulse Contribution Consent*, versioned, distinct
@@ -422,7 +427,9 @@ Pulse-contributor grant (still consent-gated), revoke, and read the audit trail.
 
 ## Open decisions
 
-All headline and secondary decisions are **resolved** (2026-07-25). Remaining
-pre-`ready` work is authoring, not deciding: the companion **ADR** for the
-sharing/consent model (Principle III) and the `patterns.md` extensions listed
-above. Flip `status: ready` once those land and the fanout summaries are agreed.
+All headline and secondary decisions are **resolved** (2026-07-25). The
+companion **[ADR 0011](../../docs/adr/0011-pulse-contributor-access-scope.md)**
+(new `pulse` scope + single-owner boundary) is authored and the `patterns.md`
+extensions are applied. Remaining before `status: ready`: agree the fanout
+summaries and add patient-readable docs on the public site. Flip `status: ready`
+to fan out. **Kept `draft` for now — nothing fans out.**

--- a/specs/041-multi-caregiver-sharing/spec.md
+++ b/specs/041-multi-caregiver-sharing/spec.md
@@ -1,0 +1,428 @@
+<!--
+  Frontmatter below is machine-read by .github/workflows/spec-fanout.yml when
+  this spec is merged into main. The `fanout` array drives which downstream
+  repos get a `[spec/<slug>] <title>` issue with the `squad` label. Fanout only
+  runs when `status:` is `ready` or `accepted` — while this is `draft` nothing
+  fans out, so it is safe to review and iterate. Flip `status: ready` (the
+  single switch) when the spec is agreed and you want the squad issues opened
+  on merge.
+
+  Allowed fanout repos: rettxweb, rettxadmin, rettxapi, rettxmutation, rettxid, templates.
+
+  STACK & DELIVERY PRE-FLIGHT (patterns.md §7): fanout targets checked against
+  patterns.md §1.
+  - rettxapi = Python 3.11 / FastAPI / Azure Functions v4 / Cosmos DB. Owns the
+    API contract, the patient_access grant model, the new invite entity, and the
+    NEW narrow `pulse` permission scope + its server-side guard.
+  - rettxweb = Angular 18 PWA wrapped with Capacitor as a NATIVE Android app
+    (iOS planned), Auth0 OIDC. Invite acceptance ties into the Auth0 sign-up /
+    email-verification path; invite/join nudges use the NATIVE FCM device-token
+    push path (Capacitor Push plugin), not Web Push/VAPID.
+  - rettxadmin = Angular 18 / Entra ID (MSAL). Admin visibility + grant/revoke.
+  - templates = per-locale Message Center templates (email + in-app + push) AND
+    the new versioned "Pulse Contribution Consent" ConsentDocument + any Auth0
+    email template changes. A missing channel file is silently skipped at
+    render, so every channel that should notify MUST have its template here.
+  - rettxid = NOT affected. The pseudonymous rettX ID is unchanged and invite
+    tokens are NOT rettX IDs. Entry intentionally omitted from fanout.
+-->
+---
+spec_id: "041"
+slug: "multi-caregiver-sharing"
+title: "Patient Sharing — Pulse Contributors (Consent-Gated, Privacy-First)"
+status: draft   # draft | ready | accepted | superseded
+authored: "2026-07-25"
+author: "perocha"
+fanout:
+  - repo: rettxapi
+    summary: |
+      Backend + OWNER of the sharing API contract. Today the `patient_access`
+      container can already REPRESENT multiple grants per patient (grants keyed
+      by `principal_id`, active-only filters `include_revoked`/`include_deleted`,
+      `query_by_principal_id` lookup) and access is enforced by
+      `require_patient_read_access_v2` (READONLY+) and
+      `require_patient_write_access_v2` (EDIT+). What is MISSING is any mechanism
+      to CREATE a share. Build the CONSTRAINED v1:
+
+      (1) New INVITE entity/container with a state machine
+      `pending → accepted | declined | expired | cancelled`, a single-use token
+      stored HASHED at rest, an expiry (default 7 days), the invited email, the
+      inviter (must be the patient OWNER), and the target patient. There is NO
+      role choice — every invite grants exactly the fixed Pulse-contributor
+      scope.
+      (2) New NARROW permission scope `pulse` (contribute), strictly weaker than
+      `edit`: it permits CREATING Pulse entries and a MINIMAL read (patient
+      display name/nickname + the Pulse tracker & history) and NOTHING else —
+      NO genetic data, NO documents, NO medical profile, and NO edit of patient
+      info. Add a `require_patient_pulse_write` dependency and ensure Pulse-write
+      endpoints accept it while every non-Pulse read/write endpoint rejects it.
+      This MUST be enforced server-side (UI hiding is not a control).
+      (3) On ACCEPT, verify the authenticated caller's VERIFIED email matches the
+      invited email (reject on mismatch), require acceptance of the current
+      Pulse Contribution Consent version, then activate a `patient_access` grant
+      at the `pulse` scope that RECORDS the accepted consent
+      (`consent_document_id` + `version` + `accepted_at` + `principal_id`).
+      (4) Revocation: only the OWNER (or admin) may revoke a contributor; a
+      contributor may self-revoke (= consent withdrawal). Revoke = soft (reuse
+      `include_revoked`); Pulse entries the contributor authored REMAIN with
+      provenance preserved.
+      (5) Pre-accept data minimization: endpoints reachable by an
+      unauthenticated/mismatched recipient MUST expose NOTHING identifying about
+      the patient.
+      (6) Rate-limit invite creation and accept attempts. Emit an AUDIT event for
+      every lifecycle transition, no PII in logs.
+      (7) Attribute every Pulse entry to the acting `principal_id`; keep visible
+      history. Trigger Message Center sends (invite, "someone joined your
+      patient") — content authored in `templates`.
+      Endpoints: create-invite, list-invites (owner), resend-invite,
+      cancel-invite, accept-invite, decline-invite, list-contributors (owner),
+      revoke-contributor.
+  - repo: rettxweb
+    summary: |
+      Caregiver-facing (Auth0, Capacitor native Android) UI:
+      (1) Owner "invite a Pulse contributor": enter email only (no role picker),
+      see pending invites, resend/cancel, and a list of active contributors with
+      revoke.
+      (2) Accept-invite flow for the invitee: land from the invite link →
+      authenticate (or Auth0 sign-up + email verification if no account) → the
+      screen reveals NOTHING identifying about the patient until the email-match
+      passes → review + accept the Pulse Contribution Consent → access granted.
+      Handle decline and expired/invalid tokens gracefully.
+      (3) Contributor's CONSTRAINED view: only the patient display name/nickname
+      + the Pulse tracker & history + the ability to add Pulse entries. No
+      genetic data, documents, medical profile, or edit surfaces. A contributor
+      may self-revoke ("leave").
+      (4) Notifications: in-app + NATIVE push (FCM device token via the Capacitor
+      Push plugin — NOT Web Push/VAPID) to the OWNER for invite sent and someone
+      joined; to the invitee for the invite itself.
+      (5) RE-CONSENT UX (net-new): the backend already enforces consent-version
+      acceptance, but rettxweb has no UI for it. Build the re-consent gate — when
+      a contributor's recorded consent version is behind the current one, block
+      further Pulse contribution and present the new consent to accept (or
+      decline = leave) before they can continue.
+  - repo: rettxadmin
+    summary: |
+      Admin-facing (Entra ID / MSAL) support path:
+      (1) View every principal who can access a patient (owner + contributors,
+      including revoked), with scope, consent status, and accepted-at.
+      (2) Admin-initiated grant of the Pulse-contributor scope — which STILL
+      requires the invitee to complete the same consent double-opt-in; admin
+      cannot silently add a contributor.
+      (3) Admin revoke and a read-only view of the invite/grant AUDIT trail.
+  - repo: templates
+    summary: |
+      Author the content this spec renders (a missing channel file is silently
+      skipped, so every notifying channel needs its files here):
+      (1) New Message Center templates, per-locale, for: Pulse-contributor invite
+      and "a contributor joined your patient" — with email (`<locale>.html` +
+      `<locale>.subject.txt`), in-app (`<locale>.inapp.txt` where the email is a
+      poor in-app fit), and push (`<locale>.push.subject.txt` +
+      `<locale>.push.txt`, generic / PHI-free).
+      (2) A new versioned "Pulse Contribution Consent" ConsentDocument, distinct
+      from the patient-creation consent and scoped to contributing Pulse
+      observations only.
+      (3) Any Auth0 email-template changes needed for the invitee sign-up /
+      email-verification path.
+---
+
+# Feature Specification: Patient Sharing — Pulse Contributors (Consent-Gated, Privacy-First)
+
+**Feature Branch**: `041-multi-caregiver-sharing`  
+**Created**: 2026-07-25  
+**Status**: Draft  
+**Input**: Control-plane brainstorm — let a patient owner share their patient
+with additional people so those people can **help log Pulse**, with **consent**
+and **privacy** as the central constraints, while keeping v1 complexity tightly
+constrained.
+
+## Decisions locked (2026-07-25)
+
+1. **Initiation** — **Both**: the patient **owner** (creator) invites
+   (self-service, primary); **admin** is a support path. Neither may bypass
+   invitee consent.
+2. **Wrong-email safeguard** — **Strictest**: nothing identifying is revealed
+   pre-acceptance; a grant activates only when the accepting identity's
+   **verified email matches** the invited address.
+3. **Constrained sharing model (single owner + Pulse contributors)** — there is
+   **one owner** (the creator) and no "co-caregiver" concept. Invitees are
+   **Pulse contributors**: they can **only create Pulse entries** and have a
+   **minimal read** (patient display name/nickname + the Pulse tracker &
+   history). They **cannot** edit patient info, see genetic data / documents /
+   medical profile, or invite/revoke anyone. There is **no role picker**.
+4. **Consent** — a **new, distinct, versioned "Pulse Contribution Consent"**,
+   scoped to contributing observations, recorded on the `patient_access` grant.
+
+**Explicitly out of scope for v1**: multiple equal owners, ownership transfer,
+and complex custody situations (e.g. divorced / dual-equal parents). These are
+accepted as corner cases to be revisited later.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Owner invites a Pulse contributor by email (Priority: P1)
+
+The patient owner wants a partner/relative/carer to help log Pulse. From the
+patient screen they enter that person's email and send an invite (no role to
+choose). They see it as `pending` and can resend or cancel it.
+
+**Why this priority**: This is the core missing capability — there is currently
+no way to create a share at all. It is the smallest slice that delivers value.
+
+**Independent Test**: Sign in as the owner, invite an email, confirm a `pending`
+invite exists and an invite message is dispatched — with no second user yet.
+
+**Acceptance Scenarios**:
+
+1. **Given** an owner viewing their patient, **When** they invite
+   `x@example.com`, **Then** a `pending` invite is created, an invite message is
+   sent to that address, and the owner sees it listed as pending.
+2. **Given** a `pending` invite, **When** the owner cancels it, **Then** its
+   state becomes `cancelled` and the token can no longer be accepted.
+3. **Given** a principal who is **not** the owner (e.g. a contributor),
+   **When** they attempt to invite someone, **Then** the request is rejected.
+
+### User Story 2 - Invitee accepts safely with consent (Priority: P1)
+
+The invited person opens the invite, authenticates (or signs up + verifies
+email), sees **nothing identifying** about the patient until their verified
+email is confirmed to match, reviews and accepts the Pulse Contribution Consent,
+and only then gains the Pulse-contributor scope.
+
+**Why this priority**: Consent + privacy are the non-negotiable constraints;
+acceptance is what actually creates access. With Story 1 this is the MVP.
+
+**Independent Test**: Follow an invite link as the correct recipient, verify no
+patient-identifying data is shown pre-acceptance, complete consent, and confirm
+an active `pulse`-scope grant carrying the consent record.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid `pending` invite, **When** the recipient authenticates with
+   a verified email that **matches** the invited address and accepts the current
+   Pulse Contribution Consent, **Then** an `active` `patient_access` grant is
+   created at the `pulse` scope, carrying the consent id/version/timestamp, and
+   the constrained contributor view becomes available.
+2. **Given** a valid `pending` invite, **When** a person authenticates with an
+   email that does **not** match, **Then** access is **not** granted and no
+   patient-identifying information is disclosed.
+3. **Given** a `pending` invite past its expiry, **When** anyone opens it,
+   **Then** it is `expired` and cannot be accepted (owner may resend).
+4. **Given** a valid invite, **When** the recipient declines, **Then** its state
+   becomes `declined` and no grant is created.
+
+### User Story 3 - Contributor logs Pulse, tightly scoped (Priority: P2)
+
+An active Pulse contributor can view the patient's name/nickname and the Pulse
+tracker & history, and can add Pulse entries. They cannot reach anything else.
+Each entry is attributed to them and is visible to the owner.
+
+**Why this priority**: This is the actual day-to-day value, but it depends on
+Stories 1–2.
+
+**Independent Test**: As a contributor, add a Pulse entry (succeeds, attributed)
+and attempt to read/edit patient profile or genetic data (all denied
+server-side).
+
+**Acceptance Scenarios**:
+
+1. **Given** a `pulse`-scope contributor, **When** they add a Pulse entry,
+   **Then** it is stored, attributed to their principal, and visible to the
+   owner in shared history.
+2. **Given** a `pulse`-scope contributor, **When** they request the patient's
+   genetic data, documents, or medical profile, or attempt to edit patient info,
+   **Then** the request is **rejected server-side**.
+3. **Given** a `pulse`-scope contributor, **When** they view the patient,
+   **Then** they see only the display name/nickname and the Pulse tracker &
+   history.
+4. **Given** a contributor whose recorded consent version is behind the current
+   Pulse Contribution Consent, **When** they open the patient to log Pulse,
+   **Then** contribution is blocked until they accept the current version
+   (declining = leave / self-revoke).
+
+### User Story 4 - Revocation & offboarding (Priority: P2)
+
+The owner (or admin) can revoke a contributor; a contributor can leave (withdraw
+consent). Access ceases immediately; Pulse entries they authored remain as the
+patient's record with provenance intact.
+
+**Why this priority**: Withdrawal must be possible at any time (Principle I).
+
+**Acceptance Scenarios**:
+
+1. **Given** an active contributor, **When** the owner revokes them, **Then**
+   the grant becomes `revoked`, access stops immediately, and their authored
+   Pulse entries remain visible with attribution.
+2. **Given** an active contributor, **When** they choose to leave, **Then** their
+   own grant is revoked (consent withdrawn).
+
+### User Story 5 - Admin support path (Priority: P3)
+
+An admin can see the owner + all contributors on a patient, initiate a
+Pulse-contributor grant (still consent-gated), revoke, and read the audit trail.
+
+**Acceptance Scenarios**:
+
+1. **Given** an admin, **When** they open a patient, **Then** they see the owner
+   and all contributors (including revoked) with scope + consent status +
+   accepted-at.
+2. **Given** an admin-initiated grant, **When** the target has not consented,
+   **Then** access is **not** active until the target completes the same consent
+   double-opt-in.
+
+### Edge Cases
+
+- Invitee has **no account** → invite routes into Auth0 sign-up + email
+  verification before the review/consent step.
+- Invitee is **already** a contributor → invite is a no-op / surfaced as
+  already-shared, not a duplicate grant.
+- Owner invites their **own** email → rejected with a clear message.
+- Token **reuse / replay** after acceptance or on another device → rejected
+  (single-use, hashed).
+- Email address **changes** at the IdP between invite and accept → match is
+  against the *verified* email at accept time.
+- Patient is **deleted** while an invite is pending → invite is invalidated.
+- Contributor authorship surfaces a name in Pulse history → other contributors
+  may see that name via entry attribution (accepted; there is no separate
+  contributor-management view for contributors).
+- Rapid repeated invites (spray) → rate-limited.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The patient **owner** (P1) and an **admin** (P3) MUST be able to
+  create an invite to grant the Pulse-contributor scope on a specific patient to
+  an email address. No other principal may invite.
+- **FR-002**: An invite MUST NOT offer a role/permission choice — it grants
+  exactly the fixed **`pulse`** (contribute) scope.
+- **FR-003**: The system MUST provide a **`pulse` permission scope** that is
+  strictly narrower than `edit`: it permits creating Pulse entries and a minimal
+  read (patient display name/nickname + Pulse tracker & history) and MUST deny
+  everything else (genetic data, documents, medical profile, any patient-info
+  edit). This MUST be enforced **server-side**.
+- **FR-004**: An invite MUST carry a state in `{pending, accepted, declined,
+  expired, cancelled}`, a single-use token **hashed at rest**, an expiry
+  (default 7 days), the invited email, the inviter (owner/admin), and the
+  patient.
+- **FR-005**: Before acceptance, the system MUST NOT disclose **any**
+  patient-identifying information (name, rettX ID, diagnosis, documents) to the
+  recipient or to any party holding the token.
+- **FR-006**: A grant MUST be activated **only** when the accepting identity's
+  **verified email matches** the invited address; on mismatch, access MUST NOT
+  be granted and no patient data disclosed.
+- **FR-007**: Acceptance MUST require the invitee to accept the **current
+  version** of the distinct **Pulse Contribution Consent**; the accepted
+  `consent_document_id`, `version`, `accepted_at`, and `principal_id` MUST be
+  recorded on the `patient_access` grant.
+- **FR-008**: Any change to the Pulse Contribution Consent version MUST trigger
+  **re-consent**: on the contributor's next action the system MUST block further
+  Pulse contribution until they accept the current version. Declining re-consent
+  is treated as withdrawal (self-revoke). *Note: the backend already enforces
+  consent-version acceptance; the **rettxweb re-consent UX is net-new and is in
+  scope for this spec** (see rettxweb fanout).*
+- **FR-009**: Consent MUST be **withdrawable** at any time; withdrawal revokes
+  the contributor's own grant.
+- **FR-010**: The owner and admin MUST be able to revoke a contributor's grant;
+  a contributor MUST be able to self-revoke. Revocation MUST be **soft** (grant
+  flagged revoked) and take effect immediately.
+- **FR-011**: Pulse entries authored by a revoked contributor MUST remain as the
+  patient's record with provenance/attribution preserved. On contributor
+  **account erasure**, attribution MUST be **pseudonymized**: retain the Pulse
+  entry, the opaque `principal_id`, and the timestamp (labelled e.g. "external
+  contributor — account removed") but drop the contributor's name and email.
+  Ordinary revocation (contributor still exists) keeps the display name.
+- **FR-012**: Every Pulse entry MUST be attributed to the acting `principal_id`
+  and be visible in the patient's shared Pulse history.
+- **FR-013**: The system MUST emit an **audit** record (timestamp, actor,
+  outcome, no PII) for every invite and grant lifecycle transition.
+- **FR-014**: The system MUST support **resend** and **cancel** of a pending
+  invite, and **decline** by the invitee.
+- **FR-015**: The system MUST **rate-limit** invite creation and accept attempts.
+- **FR-016**: The **owner** MUST be notified when an invite is sent and when a
+  contributor joins.
+- **FR-017**: Admin-initiated grants MUST follow the same consent double-opt-in;
+  admins MUST NOT be able to activate access without invitee consent.
+
+### Key Entities *(include if feature involves data)*
+
+- **Invite**: a pending offer to grant the Pulse-contributor scope. Attributes:
+  patient ref, invited email, inviter principal, state, hashed token,
+  created-at, expires-at. Lifecycle `pending → accepted | declined | expired |
+  cancelled`.
+- **PatientAccess grant** (existing, extended): patient ref, principal, scope
+  (`owner` for the creator, `pulse` for contributors), state
+  (`active | revoked`), and the **accepted Pulse Contribution Consent** record
+  (`consent_document_id`, `version`, `accepted_at`).
+- **Pulse Contribution ConsentDocument** (new): versioned legal artefact,
+  distinct from the patient-creation consent, scoped to contributing
+  observations; authored in `templates`.
+- **AuditEvent**: actor principal, action, target, timestamp, outcome — opaque
+  identifiers only.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An owner can invite a contributor and that contributor can gain
+  Pulse access in a single guided flow in **under 3 minutes** (excluding IdP
+  sign-up).
+- **SC-002**: **Zero** patient-identifying data is retrievable by a recipient
+  whose verified email does not match the invited address (verified by test).
+- **SC-003**: A `pulse`-scope contributor can retrieve **only** the patient
+  display name/nickname + Pulse data; every attempt to reach genetic data,
+  documents, medical profile, or to edit patient info is denied (verified by
+  test).
+- **SC-004**: 100% of active contributor grants carry a recorded Pulse
+  Contribution Consent (id + version + timestamp), and 100% of invite/grant
+  lifecycle transitions produce an audit record.
+- **SC-005**: A revoked contributor loses access **immediately** (next request
+  denied) while their authored Pulse entries remain attributed in history.
+
+## Constitution Check
+
+- **I — Caregivers first (NON-NEGOTIABLE)**: minimal-burden invite (no role
+  decision), withdrawal anytime, no dark patterns. ✅
+- **II — Privacy by design (NON-NEGOTIABLE)**: strict pre-accept minimization,
+  narrow `pulse` scope (contributors never see the clinical record), distinct
+  withdrawable consent, purpose limitation, verified email-match, audit. ✅✅
+- **III — Transparency (NON-NEGOTIABLE)**: pair with an ADR and patient-readable
+  docs on the sharing/consent model before `ready`. ⚠️ *(ADR to be authored.)*
+- **IV — Accuracy/accountability**: Pulse-entry provenance/attribution
+  preserved. ✅
+- **VI — Security baseline**: server-side enforcement of the narrow `pulse`
+  scope (existing `require_*_access_v2` + new `require_patient_pulse_write`),
+  hashed single-use tokens, rate limiting, full audit. ✅
+
+## Assumptions
+
+- Multi-grant `patient_access` and the `require_*_access_v2` dependencies already
+  exist in `rettxapi` (verified) and are reused; the `pulse` scope + its guard
+  are the net-new backend addition. The backend also already enforces
+  **consent-version** acceptance — the net-new work there is the **rettxweb
+  re-consent UX** (FR-008).
+- The **owner** is the patient's creator; ownership transfer and multi-owner
+  custody are **out of scope** for v1.
+- Invitee identity is established via **Auth0**; the accept flow can trigger
+  sign-up + email verification.
+- Notifications reuse the existing **Message Center** (email + in-app + native
+  push).
+- **`rettxid` is not affected**; invite tokens are not rettX IDs.
+- Default invite expiry is **7 days**.
+
+## Proposed patterns.md extensions (do not invent ad hoc)
+
+- **Permission-level vocabulary**: add a narrow **`pulse`** (contribute) scope
+  below `edit` (current levels are `owner | edit | read`), defined as
+  Pulse-create + minimal Pulse read only.
+- **Vocabulary**: *Pulse contributor* (a principal holding the `pulse` scope on
+  a patient), *Invite*, and the single-**owner** stewardship model.
+- **Invite state vocabulary**: `pending | accepted | declined | expired |
+  cancelled` (invite) and `active | revoked` (grant).
+- **ConsentDocument subtype**: *Pulse Contribution Consent*, versioned, distinct
+  from the creation consent.
+
+## Open decisions
+
+All headline and secondary decisions are **resolved** (2026-07-25). Remaining
+pre-`ready` work is authoring, not deciding: the companion **ADR** for the
+sharing/consent model (Principle III) and the `patterns.md` extensions listed
+above. Flip `status: ready` once those land and the fanout summaries are agreed.

--- a/specs/041-multi-caregiver-sharing/spec.md
+++ b/specs/041-multi-caregiver-sharing/spec.md
@@ -44,12 +44,14 @@ fanout:
       `require_patient_write_access_v2` (EDIT+). What is MISSING is any mechanism
       to CREATE a share. Build the CONSTRAINED v1:
 
-      (1) New INVITE entity/container with a state machine
+      (1) New pending **Invitation** entity/container keyed by the invited
+      EMAIL, with a state machine
       `pending → accepted | declined | expired | cancelled`, a single-use token
-      stored HASHED at rest, an expiry (default 7 days), the invited email, the
-      inviter (must be the patient OWNER), and the target patient. There is NO
-      role choice — every invite grants exactly the fixed Pulse-contributor
-      scope.
+      stored HASHED at rest, an expiry (default 7 days), the inviter (owner or
+      admin), the target patient, the fixed `pulse` scope, and the Pulse
+      Contribution Consent id/version to be accepted. There is NO role choice.
+      Invites are NOT restricted to already-registered users (Model B — invite
+      any email, provision-on-accept).
       (2) New NARROW permission scope `pulse` (contribute), strictly weaker than
       `edit`: it permits CREATING Pulse entries and a MINIMAL read (patient
       display name/nickname + the Pulse tracker & history) and NOTHING else —
@@ -57,11 +59,16 @@ fanout:
       info. Add a `require_patient_pulse_write` dependency and ensure Pulse-write
       endpoints accept it while every non-Pulse read/write endpoint rejects it.
       This MUST be enforced server-side (UI hiding is not a control).
-      (3) On ACCEPT, verify the authenticated caller's VERIFIED email matches the
-      invited email (reject on mismatch), require acceptance of the current
-      Pulse Contribution Consent version, then activate a `patient_access` grant
-      at the `pulse` scope that RECORDS the accepted consent
-      (`consent_document_id` + `version` + `accepted_at` + `principal_id`).
+      (3) RESOLVE-INVITATION-TO-GRANT on ACCEPT (post-authentication): if the
+      invitee has no rettX account they self-register via the EXISTING Auth0
+      signup (rettxapi does NOT create Auth0 users) and their Principal is
+      JIT-provisioned by the existing `ensure_principal_for_user` path; then
+      verify the authenticated principal's VERIFIED email matches `invited_email`
+      (reject on mismatch — THIS is the wrong-email enforcement point), require
+      acceptance of the current Pulse Contribution Consent version, and create the
+      `pulse` `patient_access` grant RECORDING the accepted consent
+      (`consent_document_id` + `version` + `accepted_at` + `principal_id`),
+      transitioning the invitation `pending → accepted`.
       (4) Revocation: only the OWNER (or admin) may revoke a contributor; a
       contributor may self-revoke (= consent withdrawal). Revoke = soft (reuse
       `include_revoked`); Pulse entries the contributor authored REMAIN with
@@ -77,6 +84,13 @@ fanout:
       Endpoints: create-invite, list-invites (owner), resend-invite,
       cancel-invite, accept-invite, decline-invite, list-contributors (owner),
       revoke-contributor.
+      NET-NEW pieces are exactly: (a) the pending email-keyed **Invitation**
+      entity + lifecycle; (b) the **resolve-invitation-to-grant** step
+      (verified-email-match + consent record + `pulse` grant creation); (c) the
+      invite-issue + accept endpoints. rettxapi MUST NOT gain Auth0
+      user-creation and MUST NOT change the `Principal` model — the invitee
+      self-registers via existing Auth0 signup and JIT provisioning does the
+      rest.
   - repo: rettxweb
     summary: |
       Caregiver-facing (Auth0, Capacitor native Android) UI:
@@ -141,8 +155,9 @@ constrained.
    (self-service, primary); **admin** is a support path. Neither may bypass
    invitee consent.
 2. **Wrong-email safeguard** — **Strictest**: nothing identifying is revealed
-   pre-acceptance; a grant activates only when the accepting identity's
-   **verified email matches** the invited address.
+   pre-acceptance; a grant is created only when the accepting identity's
+   **verified email matches** the invited address — enforced at **invitation
+   resolution** (see Model B below).
 3. **Constrained sharing model (single owner + Pulse contributors)** — there is
    **one owner** (the creator) and no "co-caregiver" concept. Invitees are
    **Pulse contributors**: they can **only create Pulse entries** and have a
@@ -155,6 +170,53 @@ constrained.
 **Explicitly out of scope for v1**: multiple equal owners, ownership transfer,
 and complex custody situations (e.g. divorced / dual-equal parents). These are
 accepted as corner cases to be revisited later.
+
+## Platform constraint & invite flow (Model B)
+
+rettX **cannot store a person without a pre-existing Auth0 identity** — verified
+in the live `rettxapi` code:
+
+- `Principal` (`app/models/principal/principal_models.py`) requires
+  `identities: list[Identity]` with `min_length=1`; each `Identity.user_id`
+  (Auth0 `sub`) is mandatory. There is **no** placeholder / pending principal.
+- Principals are created **only** by JIT provisioning on a user's **first
+  authenticated login** (`app/routers/users.py` `/user/profile` →
+  `PrincipalProfileServices.ensure_principal_for_user`, created with
+  `status=PROVISIONAL`). There is no other creation path.
+- `patient_access` grants **require an existing `principal_id`**: `grant_access`
+  calls `_validate_principal_exists` and 404s if it is missing
+  (`app/services/patient_access_services/patient_access_services.py`). There is
+  **no** grant-by-email and no pending grant.
+- The Auth0 client (`app/authentication/auth0_client.py`) can read / search /
+  update users and send verification emails but has **no `create_user`** —
+  rettxapi **cannot mint Auth0 accounts**.
+
+**Decision — Model B: invite any email, provision-on-accept** (Pedro,
+2026-07-26). Invites are **not** restricted to already-registered users; a
+brand-new email can be invited **without rettxapi ever creating an Auth0 user**,
+by reusing the existing Auth0 self-signup + JIT path:
+
+1. **Issue.** The owner (or admin) creates a pending **Invitation** keyed by the
+   invited **email** (net-new entity — see Key Entities). Nothing identifying
+   about the patient is exposed pre-acceptance.
+2. **Self-register (if needed).** The invitee opens the invite link. If they have
+   no rettX account they **self-register through the existing Auth0 signup** —
+   that is what mints the Auth0 identity; rettxapi does not. Their **Principal is
+   JIT-provisioned** on first authenticated login via the existing
+   `ensure_principal_for_user` path. If they already have an account, they log in.
+3. **Resolve.** After authentication, accepting the invitation **resolves it into
+   a `pulse` `patient_access` grant**: the system enforces that the authenticated
+   **principal's verified email matches `invited_email`** (this is the
+   wrong-email safeguard's enforcement point), records the Pulse Contribution
+   Consent acceptance on the grant, and transitions the invitation
+   `pending → accepted`. Decline / expiry / cancel follow the lifecycle.
+
+The **only** net-new backend pieces are therefore: **(a)** the pending
+email-keyed **Invitation** entity + its lifecycle; **(b)** the
+**resolve-invitation-to-grant** step (verified-email-match + consent record +
+`pulse` grant creation); and **(c)** the **invite-issue and accept endpoints**.
+There is **no** Auth0 `create_user` and **no** change to the `Principal`
+model — the invitee self-registers and JIT provisioning does the rest.
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -182,10 +244,11 @@ invite exists and an invite message is dispatched — with no second user yet.
 
 ### User Story 2 - Invitee accepts safely with consent (Priority: P1)
 
-The invited person opens the invite, authenticates (or signs up + verifies
-email), sees **nothing identifying** about the patient until their verified
-email is confirmed to match, reviews and accepts the Pulse Contribution Consent,
-and only then gains the Pulse-contributor scope.
+The invited person opens the invite, authenticates (or **self-registers via the
+existing Auth0 signup** if they have no account, which JIT-provisions their
+Principal on first login), sees **nothing identifying** about the patient until
+their verified email is confirmed to match, reviews and accepts the Pulse
+Contribution Consent, and only then gains the Pulse-contributor scope.
 
 **Why this priority**: Consent + privacy are the non-negotiable constraints;
 acceptance is what actually creates access. With Story 1 this is the MVP.
@@ -208,6 +271,11 @@ an active `pulse`-scope grant carrying the consent record.
    **Then** it is `expired` and cannot be accepted (owner may resend).
 4. **Given** a valid invite, **When** the recipient declines, **Then** its state
    becomes `declined` and no grant is created.
+5. **Given** an invited email with **no** rettX account, **When** the recipient
+   self-registers via the existing Auth0 signup and logs in, **Then** their
+   Principal is JIT-provisioned (no rettxapi-side Auth0 user creation) and, on
+   accepting with a matching verified email + consent, a `pulse` grant is
+   created.
 
 ### User Story 3 - Contributor logs Pulse, tightly scoped (Priority: P2)
 
@@ -344,10 +412,14 @@ Pulse-contributor grant (still consent-gated), revoke, and read the audit trail.
 
 ### Key Entities *(include if feature involves data)*
 
-- **Invite**: a pending offer to grant the Pulse-contributor scope. Attributes:
-  patient ref, invited email, inviter principal, state, hashed token,
-  created-at, expires-at. Lifecycle `pending → accepted | declined | expired |
-  cancelled`.
+- **Invitation** (net-new): a pending, **email-keyed** offer to grant the
+  Pulse-contributor scope, resolved into a grant on acceptance. Fields: `id`,
+  `patient_id`, `invited_email`, `scope` (fixed `pulse`), `consent_document_id` +
+  `version` (the Pulse Contribution Consent to be accepted), `token` (hashed at
+  rest), `status` (`pending → accepted | declined | expired | cancelled`),
+  `created_at`, `expires_at` (7 days). Nothing identifying about the patient is
+  exposed pre-acceptance; `invited_email` is the wrong-email safeguard's anchor
+  (matched against the accepting principal's verified email at resolution).
 - **PatientAccess grant** (existing, extended): patient ref, principal, scope
   (`owner` for the creator, `pulse` for contributors), state
   (`active | revoked`), and the **accepted Pulse Contribution Consent** record

--- a/specs/041-multi-caregiver-sharing/spec.md
+++ b/specs/041-multi-caregiver-sharing/spec.md
@@ -30,7 +30,7 @@
 spec_id: "041"
 slug: "multi-caregiver-sharing"
 title: "Patient Sharing — Pulse Contributors (Consent-Gated, Privacy-First)"
-status: draft   # draft | ready | accepted | superseded
+status: ready   # draft | ready | accepted | superseded
 authored: "2026-07-25"
 author: "perocha"
 fanout:


### PR DESCRIPTION
## Summary

Draft cross-cutting spec (`status: draft` — **nothing fans out until flipped**) for letting a patient **owner** share their patient with additional people so they can help **log Pulse**, with **consent** and **privacy** as the central constraints. Kept deliberately simple for v1.

### Model (decisions locked 2026-07-25)
- **Single owner** (the creator) is the only administrator — no "co-caregiver" concept, no role picker.
- Invitees are **Pulse contributors**: a new **narrow, server-enforced `pulse` scope** — create Pulse entries + **minimal read** (patient display name/nickname + Pulse tracker & history) and *nothing else* (no genetic data, documents, medical profile, or patient-info edit).
- **Initiation:** owner self-service (primary) + admin support path — both consent-gated.
- **Privacy:** strict double-opt-in, **verified email-match**, nothing identifying revealed pre-accept, **7-day** invite expiry, rate-limited, fully audited.
- **Consent:** distinct versioned **Pulse Contribution Consent**; **hard-block re-consent** on any version change — the missing **rettxweb re-consent UX is pulled into scope**.
- **Erasure:** on contributor account erasure, attribution is **pseudonymized** (keep entry + opaque `principal_id` + timestamp, drop name/email); ordinary revocation keeps the name.

### Constitution check
I ✅ · II ✅✅ (contributors never touch the clinical record) · III ⚠️ *(companion ADR still to be authored)* · IV ✅ · VI ✅.

### Grounding (verified in `rettxapi`, treated as ground truth)
`patient_access` already represents multiple grants per patient with `include_revoked`/`include_deleted` filters and `query_by_principal_id`; enforced by `require_patient_read_access_v2` / `require_patient_write_access_v2`. **Missing:** any mechanism to *create* a share — this spec adds it, plus the net-new `pulse` scope guard.

### Files
- `specs/041-multi-caregiver-sharing/spec.md` — the draft spec (5 prioritized user stories, 17 FRs, entities, success criteria, fanout to rettxapi/rettxweb/rettxadmin/templates; `rettxid` explicitly none).
- `specs/041-multi-caregiver-sharing/research.md` — design-options record with trade-offs and recommendations behind each decision.

### Remaining before `status: ready` (authoring, not deciding)
- Companion **ADR** for the sharing/consent model (Principle III).
- **`patterns.md`** extensions: new `pulse` permission level, invite-state vocabulary, *Pulse Contribution Consent* subtype.

> Control-plane only — no downstream repos edited. Fanout summaries are drafted but dormant while `status: draft`.