### PR TITLE
docs(specs): admin app shell (042) + RBAC MVP (043) + ADR 0012

### DIFF
--- a/.specify/memory/patterns.md
+++ b/.specify/memory/patterns.md
@@ -105,7 +105,25 @@ are coordinated through a cross-cutting spec.
 - **Clinician** — authorised medical professional with access scoped by
   permissions.
 - **Admin** — registry operator with administrative access via the admin
-  surface.
+  surface. Admins authenticate via **Microsoft Entra ID (MSAL)**, not Auth0.
+- **Entra App Role** — the **source of truth for admin authorization**. Admin
+  roles are provisioned as App Roles in the Entra app registration and delivered
+  in the verified access-token **`roles` claim**; `rettxapi` reads that claim to
+  authorize admin requests. This is deliberately **not** a DB-driven
+  `Principal.role` — admins are Entra principals that may have no `Principal`
+  record (see [ADR 0012](../../docs/adr/0012-admin-rbac-entra-app-roles.md)).
+- **Admin role set (MVP)** — the thin admin RBAC vocabulary
+  (specs 042/043, ADR 0012): `super_admin` (owner / break-glass; superset of all
+  checks), `admin` (base operator role required by every admin endpoint), and
+  `read_only` (view admin data, no mutations). Finer permissions extend the same
+  `roles` claim later. These are **admin authorization** roles and are distinct
+  from the caregiver **Permission level** (`owner`/`edit`/`read`) below and from
+  the account-lifecycle `Principal.status` (`PROVISIONAL`/`ACTIVE`/`LOCKED`).
+- **`RBAC_ENABLED`** — the rollout flag convention for admin RBAC. Admin role
+  enforcement in `rettxapi` is gated behind `RBAC_ENABLED` (**default OFF**) so
+  roles cannot lock admins out before Entra App Roles are provisioned and
+  assigned. Enable sequence: provision App Roles → assign → verify the `roles`
+  claim appears in tokens → flip the flag on.
 - **Mutation** — a genetic variant recorded against a patient, expressed in
   HGVS where applicable. Extraction and validation are delegated to the
   [`rettxmutation`](https://github.com/rett-europe/rettxmutation) library.
@@ -149,6 +167,20 @@ be reconciled, not a feature.
 
 Authorization is **always** enforced server-side. UI gating is a usability
 courtesy, not a security control.
+
+**Admin authorization (RBAC).** Admin authorization uses **Entra App Roles** as
+the source of truth: roles are provisioned in the Entra app registration and
+delivered in the verified token **`roles` claim**, which `rettxapi` enforces
+server-side via a reusable `require_role(*roles)` / `require_permission(perm)`
+dependency layered on `get_admin_id`. The MVP role set is `super_admin` /
+`admin` / `read_only` (see §2). Admin roles do **not** live in the DB
+(`Principal` is the caregiver identity and may not exist for an admin) and admin
+is **not** migrated to Auth0 — the backend trusts Entra tokens only for admin.
+Enforcement rolls out behind the `RBAC_ENABLED` flag (default OFF). `rettxadmin`
+reflects the `roles` claim to gate nav items and routes, but that is **UX only**;
+the API is the boundary. See [spec 043](../../specs/043-admin-rbac-mvp/spec.md),
+[spec 042](../../specs/042-admin-app-shell/spec.md), and
+[ADR 0012](../../docs/adr/0012-admin-rbac-entra-app-roles.md).
 
 ## 5. Internationalization
 
@@ -347,3 +379,4 @@ GitHub docs on
 | 2026-07-11 | §1/§5: renamed the Message Center template folder `emails/` → **`messages/`** ([ADR 0006](../../docs/adr/0006-message-center-template-store-layout.md), Accepted) since it now carries email + in-app + push content; documented the per-channel file-suffix convention. Deploy strips the folder prefix, so the blob container stays `email-templates` and `rettxapi` is unaffected. |
 | 2026-07-11 | Added §10 **AI-assisted code review & custom instructions** ([ADR 0007](../../docs/adr/0007-ai-code-review-custom-instructions.md)): every repo must maintain a review-focused `.github/copilot-instructions.md`; path-specific rules go in `.github/instructions/*.instructions.md` with `applyTo:` frontmatter (never in the repo-wide file); files stay concise and enforce the cross-cutting non-negotiables (PHI, auth, i18n, contract ownership, test integrity). Renumbered the change log to §11. Prompted by an audit showing all repos have the file but content was uneven/agent-oriented (e.g. `rettxweb` thin, `rettxapi` with a stray `applyTo:` in the repo-wide file). |
 | 2026-07-11 | §6: retired the autonomous **Squad/Ralph** toolkit (the `squad-*.yml` workflows and `.squad/` directories) across the downstream repos. The `squad` label is **retained** as the fan-out inbox marker, now picked up by a human/orchestrated working session rather than an automated agent. See [ADR 0008](../../docs/adr/0008-retire-autonomous-squad-agent-system.md). |
+| 2026-07-26 | §2/§4: added the **admin RBAC** vocabulary and conventions — **Entra App Role** as the admin-authorization source of truth (the token `roles` claim), the MVP role set (`super_admin`/`admin`/`read_only`), and the **`RBAC_ENABLED`** flag-gated rollout convention (default OFF). Reinforced §4 that admin authorization is enforced **server-side** in `rettxapi` via a `require_role`/`require_permission` dependency, admin stays on **Entra** (not Auth0, not a DB `Principal.role`), and client gating is UX only. Prompted by the admin app maturity program — see [spec 042](../../specs/042-admin-app-shell/spec.md) (gated login + config-driven left nav with a `requiredRoles` extension point), [spec 043](../../specs/043-admin-rbac-mvp/spec.md) (RBAC MVP), and [ADR 0012](../../docs/adr/0012-admin-rbac-entra-app-roles.md). |

--- a/docs/adr/0012-admin-rbac-entra-app-roles.md
+++ b/docs/adr/0012-admin-rbac-entra-app-roles.md
@@ -1,0 +1,123 @@
+# ADR 0012 — Admin RBAC via Microsoft Entra App Roles
+
+- **Status**: Proposed (2026-07-26)
+- **Date**: 2026-07-26
+- **Decision-makers**: rettX maintainers (Pedro)
+- **Relates to**: [spec 043 — Admin RBAC MVP](../../specs/043-admin-rbac-mvp/spec.md)
+  (the enforcement + rollout this ADR governs),
+  [spec 042 — Admin app shell](../../specs/042-admin-app-shell/spec.md)
+  (the config-driven nav whose `requiredRoles` slot consumes these roles on the
+  client), [patterns.md §4](../../.specify/memory/patterns.md)
+  (authentication & authorization), and the program constitution
+  **Principle VI (Security baseline)** — server-side authorization and least
+  privilege.
+
+## Context
+
+The rettX admin surface (`rettxadmin`) and backend (`rettxapi`) today have
+**authentication but no authorization** for admins.
+
+- **Two deliberate identity planes.** Admin/staff authenticate via **Microsoft
+  Entra ID (Azure AD) using MSAL**; caregivers authenticate via **Auth0**. This
+  split is intentional. `rettxapi` admin endpoints trust **Entra tokens only**
+  (`require_admin` → `get_admin_id` → `EntraClient`, `auth_provider="entra"`).
+- **No RBAC exists.** In `app/authentication/entra_client.py`, `get_user_info()`
+  **hardcodes `is_admin=True`**, and the real roles-claim check
+  (`is_admin = payload.get('roles', []) == ["admin"]`) is **commented out**. Any
+  authenticated Entra admin therefore has full, undifferentiated access.
+- **The `Principal` model is the wrong home for admin roles.** `Principal`
+  (`app/models/principal/principal_models.py`) represents the **Auth0/caregiver**
+  identity and carries only an account-lifecycle `status`
+  (`PROVISIONAL`/`ACTIVE`/`LOCKED`) — **not** an authorization field. Crucially,
+  **admins are Entra principals and may have no `Principal` record at all**.
+- On the client, `rettxadmin` guards routes with `MsalGuard` (authentication
+  only); there is no role concept. Spec 042 introduces a config-driven nav with
+  an optional `requiredRoles` extension point awaiting a role source.
+
+We need a source of truth for **admin** authorization that (a) fits Entra
+identities that may lack a `Principal` record, (b) is enforced server-side, and
+(c) can be rolled out without locking existing admins out.
+
+## Decision
+
+**Adopt Microsoft Entra App Roles as the source of truth for admin
+authorization.**
+
+1. **Roles ride the token.** Admin roles are delivered in the verified Entra
+   access-token **`roles` claim**. `rettxapi` reads the claim it already trusts
+   (from existing signature/issuer/audience validation) — it does not add a new
+   identity lookup.
+2. **Thin MVP role set:** `super_admin` (owner / break-glass; superset of all
+   checks), `admin` (base operator role required by every admin endpoint), and
+   `read_only` (view without mutate). Finer permissions can extend the same claim
+   later.
+3. **Server-side enforcement is the boundary.** A reusable dependency
+   (`require_role(*roles)` / `require_permission(perm)` in
+   `app/dependencies/admin_permissions.py`), layered on `get_admin_id`, gates
+   admin routers. `get_user_info()` stops hardcoding `is_admin=True` and instead
+   surfaces `UserInfo.roles: list[str]`.
+4. **Flag-gated rollout.** Enforcement sits behind `RBAC_ENABLED`
+   (**default OFF**). The enable sequence is: provision App Roles in the Entra
+   app registration → assign to users/groups → verify the `roles` claim appears
+   in issued tokens → flip `RBAC_ENABLED=on`.
+5. **Client gating is UX only.** `rettxadmin` reflects roles from the MSAL
+   `roles` claim to gate nav items (via spec 042's `requiredRoles`) and routes,
+   but never as a security control — the API decides.
+
+## Consequences
+
+**Positive**
+
+- **Fits the identity model.** Admin authorization attaches to the **Entra**
+  identity that actually authenticates admins, with no dependency on a
+  caregiver-oriented `Principal` record that admins may not have.
+- **Single source of truth.** Roles live in Entra and travel in the token; there
+  is no second store to keep in sync, and no split between identity and authz.
+- **Server-side, auditable enforcement** satisfies Constitution Principle VI and
+  patterns.md §4; the client can only reflect access, never grant it.
+- **Safe rollout.** `RBAC_ENABLED=off` preserves today's behaviour until App
+  Roles are provisioned and assigned, eliminating lock-out risk.
+- **Extensible.** Finer-grained permissions can be layered onto the same `roles`
+  claim without re-architecting identity.
+
+**Negative / costs**
+
+- **Ops dependency.** Requires Azure AD **App Role provisioning and assignment**;
+  role changes are managed in Entra (a directory/admin task), not in the app DB.
+- **Coordinated cross-repo change.** rettxapi (enforcement) and rettxadmin
+  (reflection) must land together, tracked by spec 043 and fanned out as two
+  `squad` issues.
+- **Token/claim dependency.** If App Roles are misconfigured, tokens may omit the
+  `roles` claim; the default-off flag and the "verify the claim" rollout step
+  mitigate this, but it must be checked before enabling.
+- **Coarse to start.** The three-role MVP does not model per-operation
+  permissions yet; separation-of-duty beyond `super_admin`/`admin`/`read_only`
+  is a follow-up on the same claim.
+
+## Alternatives considered
+
+- **DB-driven `Principal.role`.** *Rejected.* Admins are Entra principals that
+  may have **no `Principal` record** (Principal = the Auth0/caregiver identity),
+  so a DB role field does not cleanly cover admin identities. It also **splits
+  the identity source of truth** between Entra (authentication) and the DB
+  (authorization) and adds moving parts (persistence, sync, lifecycle).
+- **Static allow-list of admin emails in config.** *Rejected.* Brittle and
+  unauditable: no granularity (all-or-nothing), changes require a redeploy or
+  config edit, and there is no directory-level record of who was granted what or
+  when.
+- **Move admin to Auth0 + Auth0 RBAC.** *Rejected.* Contradicts the backend's
+  **Entra-only** admin trust (`auth_provider="entra"`), would break admin
+  authentication, and imposes a larger migration for no benefit — the admin plane
+  is deliberately on Entra.
+- **Client-side-only gating in `rettxadmin`.** *Rejected.* UI gating is not a
+  security control (Constitution Principle VI); anyone can bypass a hidden menu
+  item by calling the API directly. Client gating stays, but only as UX on top of
+  server-side enforcement.
+
+## Cross-links
+
+- [spec 043 — Admin RBAC MVP](../../specs/043-admin-rbac-mvp/spec.md)
+- [spec 042 — Admin app shell](../../specs/042-admin-app-shell/spec.md)
+- [patterns.md §4 — Authentication & authorization](../../.specify/memory/patterns.md)
+- Constitution **Principle VI (Security baseline)** — server-side authorization,
+  least privilege, auditability.

--- a/specs/042-admin-app-shell/spec.md
+++ b/specs/042-admin-app-shell/spec.md
@@ -1,0 +1,291 @@
+<!--
+  Frontmatter below is machine-read by .github/workflows/spec-fanout.yml when
+  this spec is merged into main. Fanout only runs when status is `ready` or
+  `accepted` — while `draft` nothing fans out, so it is safe to review and
+  iterate. Flip `status: ready` when agreed and you want squad issues opened
+  on merge.
+-->
+---
+spec_id: "042"
+slug: "admin-app-shell"
+title: "rettX Admin — gated login screen + config-driven left navigation shell"
+status: draft   # draft | ready | accepted | superseded
+authored: "2026-07-26"
+author: "perocha"
+source_issue: ""
+relates_to: "specs/043-admin-rbac-mvp/"
+fanout:
+  - repo: rettxadmin
+    summary: |
+      OWNER and the ONLY affected repo. This is a UX/shell change to the
+      Angular 18 standalone admin app; there is NO rettxapi or rettxid change.
+      Keep the identity plane exactly as-is: admin/staff authenticate via
+      **Microsoft Entra ID (Azure AD) using MSAL** (`@azure/msal-angular` v3 +
+      `@azure/msal-browser`) with the **redirect** flow. Auth0 is the caregiver
+      plane and is explicitly OUT OF SCOPE here — do not introduce Auth0 into
+      rettxadmin.
+
+      Deliver two things: (A) a dedicated gated login screen, and (B) a
+      config-driven left sidenav that replaces the hardcoded top toolbar nav.
+
+      (A) DEDICATED MSAL/ENTRA LOGIN SCREEN.
+      Today there is NO login page: the app uses the home page plus login
+      buttons in the top `mat-toolbar` (MSAL redirect). Add a real gate:
+      - Unauthenticated users see ONLY a dedicated login screen (a clean,
+        branded page with a single "Sign in with Microsoft" action that starts
+        the existing MSAL redirect). No app chrome, no nav, no feature routes
+        are reachable while unauthenticated.
+      - Authenticated users see the full app shell (sidenav + routed content).
+      - Preserve the current MSAL redirect posture and the existing
+        `login-failed` route (`FailedComponent`) as the redirect failure target.
+      - Keep `MsalGuard` doing AUTHENTICATION only — do not add authorization
+        here (that is spec 043). The gate is: no MSAL account ⇒ login screen;
+        MSAL account ⇒ shell.
+      - Note the app is localhost-only today (no external exposure yet); this is
+        the moment to add the proper gate before it is hosted, not after.
+
+      (B) LEFT SIDENAV, CONFIG-DRIVEN, REPLACING THE TOP TOOLBAR.
+      Today `app.component.html` hardcodes 8+ literal `<a mat-button>` links in a
+      top `mat-toolbar`, English-only, no grouping, no icons, no
+      `MatSidenavModule`. Replace this with a proper shell:
+      - Introduce `MatSidenavModule` (+ `MatListModule`, `MatIconModule`): a
+        LEFT sidenav for navigation and a slim top bar that keeps the account /
+        sign-out control and the mobile hamburger toggle.
+      - Drive the menu from a TYPED CONFIG DATA STRUCTURE, not template literals.
+        Define a nav model, e.g.:
+        `interface AdminNavItem { labelKey: string; icon: string; route?: string;
+        children?: AdminNavItem[]; requiredRoles?: string[]; featureFlag?: string; }`
+        and an `interface AdminNavGroup { labelKey: string; items: AdminNavItem[]; }`
+        Render the sidenav by iterating this config so adding/reordering items is
+        a data edit, not a template edit. Put the config in a dedicated file
+        (e.g. `src/app/core/navigation/admin-nav.config.ts`) and a presentational
+        `SidenavComponent` that consumes it.
+      - GROUP the current ~19 routes into logical sections with Material Icons.
+        The live route table (src/app/app.routes.ts on main) is the source of
+        truth; map the navigable (non-detail, non-redirect, non-login) routes as:
+          * Overview     → `data` (DataComponent)                      icon: dashboard
+          * Patients     → `patients` (list; `patients/:id` is a detail,
+                           reached from the list, not a top nav item)   icon: groups
+          * Users & Access → `users` (UserSearchComponent)              icon: manage_accounts
+          * Surveys      → `survey-command-center` (primary),
+                           `surveys` (list; `surveys/:id` detail),
+                           `survey-campaigns/add`, `survey-campaigns/:id`
+                           (the bare `survey-campaigns` and `survey-assignments`
+                           paths are redirects into the command center — do NOT
+                           surface them as separate items);
+                           `survey-command-center/assign/:campaignId` is a
+                           workspace reached from within, not a top item   icon: assignment
+          * Campaigns    → `email-campaigns` (list; `create`, `:campaignId`,
+                           `:campaignId/edit` are sub-flows)             icon: campaign
+          * Genetics     → `mecp2-distribution` (Mecp2DistributionComponent) icon: biotech
+          * Pulse        → `pulse-catalog` (KEEP its existing
+                           `pulseCatalogGuard` feature-flag gate; expose the item
+                           via the config `featureFlag: 'pulseCatalog'` slot so it
+                           only shows when the flag is on)               icon: monitoring
+        `home` (`''`) is the shell landing/redirect target, and `login-failed`
+        belongs to the login flow — neither is a sidenav item. Confirm the exact
+        set against the real route table at implementation time and group
+        faithfully; the grouping above is the intended shape, not a literal
+        contract. If a route has been added/removed since this spec, fold it into
+        the nearest group rather than leaving it un-navigable.
+      - RESPONSIVE: persistent/`side` mode sidenav on desktop; `over` mode with a
+        hamburger toggle on mobile (use `BreakpointObserver`). The sign-out /
+        account control stays reachable in both.
+      - I18N-READY: every label is a translation KEY (e.g. `nav.patients`,
+        `nav.surveys`), resolved through the existing i18n mechanism. English is
+        the only populated locale for now, but reserve the keys and route all nav
+        text through translation so a later locale pass needs no structural change.
+        (Admin i18n file naming follows patterns.md §5 — ISO 3166-1 country codes.)
+      - ROLE-AWARE EXTENSION POINT ONLY: the nav item shape carries an OPTIONAL
+        `requiredRoles?: string[]` field. Spec 042 DEFINES this slot but
+        implements NO role logic — every item renders for every authenticated
+        user for now. Spec 043 (Admin RBAC MVP) consumes `requiredRoles` to gate
+        items. Do not read roles, filter items by role, or add a role guard in
+        this spec; just make the field exist and be passed through untouched.
+
+      ACCESSIBILITY: the shell must be keyboard-navigable, screen-reader labelled
+      (landmark `nav`, `aria-current` on the active item), and honour reduced
+      motion (Constitution Principle V, WCAG 2.2 AA). Predictable navigation is a
+      first-class requirement, not polish.
+
+      OUT OF SCOPE (do not do here): any Auth0 work; any authorization/role
+      enforcement (spec 043); any rettxapi change; renaming routes or changing
+      route paths; new features behind the nav.
+---
+
+# rettX Admin — gated login screen + config-driven left navigation shell
+
+## Problem
+
+`rettxadmin` is an Angular 18 standalone + Angular Material admin app that has
+outgrown its initial shell. Two structural gaps:
+
+1. **No real login gate.** There is no dedicated login page. Unauthenticated
+   users land on the home page and sign in via login buttons in the top
+   `mat-toolbar` (MSAL redirect). `MsalGuard` protects individual feature routes
+   for authentication, but the app has no single, deliberate "you must sign in"
+   surface. The app is localhost-only today, so this has been tolerable — but it
+   must be fixed **before** the app is exposed, not after.
+2. **Hardcoded, flat navigation.** Navigation is 8+ literal `<a mat-button>`
+   links baked into a top `mat-toolbar` in `app.component.html`. There is no
+   `MatSidenavModule`, no config-driven menu, no grouping, no icons, and no
+   i18n on nav labels. With ~19 feature routes this no longer scales, and there
+   is nowhere clean for role-based gating (spec 043) to hook in.
+
+This spec modernises the admin **shell** — a gated login screen plus a
+config-driven left sidenav — without touching the backend or the identity plane.
+
+## Identity plane (unchanged)
+
+Admin/staff authenticate via **Microsoft Entra ID (Azure AD) with MSAL**
+(`@azure/msal-angular` v3, redirect flow). This is deliberate and stays:
+`rettxapi` admin endpoints trust **Entra tokens only**. **Auth0 is the caregiver
+plane and is explicitly out of scope for the admin app** — see
+[patterns.md §4](../../.specify/memory/patterns.md) and
+[ADR 0012](../../docs/adr/0012-admin-rbac-entra-app-roles.md). This spec keeps
+MSAL/Entra end to end.
+
+## Goals
+
+1. A **dedicated, gated MSAL login screen**: unauthenticated ⇒ login screen only;
+   authenticated ⇒ full app shell. Redirect posture preserved; `login-failed`
+   retained as the failure target.
+2. A **left sidenav** (`MatSidenavModule`) replacing the top-toolbar nav, driven
+   by a **typed config data structure** (not template literals), organised into
+   logical **groups** with **Material Icons**.
+3. **Responsive** behaviour: persistent on desktop, collapsible/hamburger on
+   mobile.
+4. **i18n-ready** labels: every nav string is a translation key, reserved now
+   even though only English is populated.
+5. A **role-aware extension point**: an optional `requiredRoles` field on each
+   nav item, defined here and consumed later by spec 043. No role logic ships in
+   this spec.
+
+## Non-goals
+
+- No authorization / role enforcement — that is [spec 043](../043-admin-rbac-mvp/spec.md).
+- No Auth0 in the admin app; no change to the Entra-only admin trust.
+- No `rettxapi` or `rettxid` change.
+- No route renames or new features; this is purely the shell.
+
+## Nav model (the config-driven menu)
+
+The menu is data, not markup. Proposed shape (final names at implementation
+time):
+
+```ts
+interface AdminNavItem {
+  labelKey: string;        // i18n key, e.g. 'nav.patients'
+  icon: string;            // Material icon name
+  route?: string;          // Angular route; absent for pure group headers
+  children?: AdminNavItem[];
+  requiredRoles?: string[]; // EXTENSION POINT for spec 043 — unused here
+  featureFlag?: string;    // e.g. 'pulseCatalog' — hides item when flag off
+}
+
+interface AdminNavGroup {
+  labelKey: string;
+  items: AdminNavItem[];
+}
+```
+
+A presentational `SidenavComponent` iterates `AdminNavGroup[]` from a dedicated
+config file. Adding, reordering, grouping, or (later) role-gating an item is a
+data edit.
+
+## Proposed grouping of the current routes
+
+Grounded in the live `src/app/app.routes.ts` (main). Detail routes
+(`patients/:id`, `surveys/:id`, campaign sub-flows), redirect stubs
+(`survey-campaigns`, `survey-assignments`), the `home` landing, and
+`login-failed` are **not** sidenav items.
+
+| Group | Nav item(s) → route | Icon |
+|---|---|---|
+| Overview | `data` | `dashboard` |
+| Patients | `patients` (list) | `groups` |
+| Users & Access | `users` | `manage_accounts` |
+| Surveys | `survey-command-center`, `surveys`, `survey-campaigns/add` | `assignment` |
+| Campaigns | `email-campaigns` | `campaign` |
+| Genetics | `mecp2-distribution` | `biotech` |
+| Pulse | `pulse-catalog` (feature-flag gated) | `monitoring` |
+
+`pulse-catalog` keeps its existing `pulseCatalogGuard` feature-flag gate and is
+surfaced through the config `featureFlag: 'pulseCatalog'` slot (hidden when the
+flag is off). Confirm the exact route set at implementation time and fold any
+newly added route into the nearest group.
+
+## Login screen
+
+- Unauthenticated: a single dedicated, branded screen with one
+  "Sign in with Microsoft" action that starts the existing MSAL redirect. No
+  sidenav, no feature chrome.
+- Authenticated: the full shell (sidenav + routed content).
+- `login-failed` (`FailedComponent`) remains the redirect failure target.
+- `MsalGuard` stays authentication-only; no authorization added here.
+
+## Responsive & accessibility
+
+- Desktop: persistent (`side`) sidenav. Mobile: `over` mode with a hamburger
+  toggle (`BreakpointObserver`). Account / sign-out reachable in both.
+- Keyboard-navigable; `nav` landmark; `aria-current` on the active item;
+  respects reduced motion. Target **WCAG 2.2 AA** (Constitution Principle V).
+
+## Constitution Check
+
+- **Principle V (Accessibility & inclusion):** the shell targets WCAG 2.2 AA,
+  keyboard and screen-reader support, predictable navigation, and reduced-motion
+  respect; nav labels are i18n keys so the admin surface can be localised.
+- **Principle VI (Security baseline):** the login gate strengthens the
+  authentication boundary before the app is exposed; MSAL/Entra and short-lived
+  tokens are unchanged. This spec adds **no** authorization — it only reserves
+  the `requiredRoles` extension point; server-side enforcement remains the
+  security control (delivered in spec 043), never the client shell.
+- **Patterns §4 (Authentication & authorization):** admin stays on Microsoft
+  Entra ID (MSAL); Auth0 is not introduced into the admin plane.
+- **Patterns §5 (Internationalization):** nav text routes through translation
+  keys (admin i18n uses ISO 3166-1 country-code file names).
+
+## Acceptance criteria
+
+- [ ] Unauthenticated users see ONLY a dedicated MSAL login screen; no sidenav
+      or feature route is reachable until an MSAL account exists.
+- [ ] "Sign in with Microsoft" starts the existing MSAL redirect; `login-failed`
+      remains the failure target; Auth0 is not present in the admin app.
+- [ ] The top-toolbar nav is replaced by a LEFT `MatSidenavModule` sidenav.
+- [ ] The menu is rendered from a TYPED CONFIG structure (`AdminNavGroup[]` /
+      `AdminNavItem`), not from hardcoded template links.
+- [ ] Items are grouped into logical sections with Material Icons, covering the
+      current navigable routes (Overview, Patients, Users & Access, Surveys,
+      Campaigns, Genetics, Pulse).
+- [ ] `pulse-catalog` shows only when its feature flag is on (existing behaviour
+      preserved via the config `featureFlag` slot).
+- [ ] The sidenav is persistent on desktop and collapsible/hamburger on mobile;
+      account/sign-out reachable in both.
+- [ ] Every nav label is an i18n translation key (English populated).
+- [ ] Each nav item supports an OPTIONAL `requiredRoles` field that is defined
+      and passed through but not yet acted on (no role filtering in this spec).
+- [ ] Shell is keyboard-navigable and screen-reader labelled (`nav` landmark,
+      `aria-current`), honouring reduced motion.
+- [ ] No rettxapi / rettxid change; no route renames; no Auth0.
+
+## Open questions
+
+- **Overview naming:** `DataComponent` at `/data` is surfaced as "Overview" —
+  confirm the intended label/role of this page (dashboard vs. a specific data
+  view) and rename the key if needed.
+- **Group ordering & collapse:** should groups be collapsible accordions, or a
+  flat grouped list? (Recommend flat grouped list for the MVP; revisit if the
+  route count grows.)
+- **Deep-link on unauth:** when an unauthenticated user hits a deep link, do we
+  round-trip them back to the target after MSAL login, or land on Overview?
+  (Recommend: preserve and return to the requested route.)
+
+## Relationships
+
+- Pairs with **[spec 043 — Admin RBAC MVP](../043-admin-rbac-mvp/spec.md)**,
+  which consumes the `requiredRoles` extension point defined here.
+- Aligns with **[ADR 0012 — Admin RBAC via Entra App Roles](../../docs/adr/0012-admin-rbac-entra-app-roles.md)**
+  (admin stays on Entra).
+- Conventions: **[patterns.md §4](../../.specify/memory/patterns.md)** (auth),
+  **§5** (i18n).

--- a/specs/043-admin-rbac-mvp/spec.md
+++ b/specs/043-admin-rbac-mvp/spec.md
@@ -1,0 +1,280 @@
+<!--
+  Frontmatter below is machine-read by .github/workflows/spec-fanout.yml when
+  this spec is merged into main. Fanout only runs when status is `ready` or
+  `accepted` — while `draft` nothing fans out, so it is safe to review and
+  iterate. Flip `status: ready` when agreed and you want squad issues opened
+  on merge.
+-->
+---
+spec_id: "043"
+slug: "admin-rbac-mvp"
+title: "rettX Admin — RBAC MVP with Entra App Roles as the source of truth"
+status: draft   # draft | ready | accepted | superseded
+authored: "2026-07-26"
+author: "perocha"
+source_issue: ""
+relates_to: "specs/042-admin-app-shell/"
+fanout:
+  - repo: rettxapi
+    summary: |
+      OWNER of enforcement — this is the security boundary (Constitution
+      Principle VI / patterns.md §4). Introduce ADMIN role-based access control
+      using **Microsoft Entra App Roles** as the source of truth: roles arrive in
+      the verified Entra access token `roles` claim. Admins authenticate via
+      **Entra only** — do NOT introduce Auth0 or a DB-driven role here (see
+      [ADR 0012](../../docs/adr/0012-admin-rbac-entra-app-roles.md) for why:
+      admins are Entra principals that may have NO rettX `Principal` record).
+
+      (1) STOP HARDCODING ADMIN. In `app/authentication/entra_client.py`,
+      `get_user_info()` currently HARDCODES `is_admin=True` and the real
+      roles-claim check is COMMENTED OUT. Replace the hardcode: extract the
+      `roles` claim from the ALREADY-VERIFIED Entra token and surface it. Add
+      `roles: list[str]` to `UserInfo` (keep the derived `is_admin: bool` for
+      backwards compatibility, computed as "has the base admin role"). Do not
+      change token *validation* (signature/issuer/audience) — only read the
+      claim that verification already trusts. If the claim is absent, roles is an
+      empty list (no roles), NOT admin.
+
+      (2) MINIMAL ROLE SET (keep it thin, justify each). Define exactly three
+      MVP roles:
+        - `super_admin` — full access incl. sensitive/destructive operations and
+          (future) role/config management. The break-glass / owner role.
+        - `admin` — the standard operator role. Grants access to all existing
+          admin endpoints (the current behaviour, now explicit instead of
+          hardcoded). This is the BASE admin role every admin endpoint requires.
+        - `read_only` — can view admin data but cannot mutate; for auditors /
+          support who need visibility without change rights.
+      Rationale for thinness: these three cover the real personas today (owner,
+      operator, viewer) without over-modelling permissions before we have
+      concrete separation-of-duty requirements. Finer-grained permissions can be
+      added later on the SAME claim without re-architecture.
+
+      (3) REUSABLE AUTHORIZATION DEPENDENCY. Add
+      `app/dependencies/admin_permissions.py` with a dependency factory layered
+      ON TOP of the existing `get_admin_id` (which resolves the authenticated
+      Entra admin). Provide:
+        - `require_role(*roles)` → FastAPI dependency that 403s unless the
+          caller's `roles` claim intersects the allowed set (super_admin
+          implicitly satisfies any role check — treat it as a superset).
+        - Optionally `require_permission(perm)` mapping a coarse permission to
+          the role set, so call sites read int/`require_permission('patients:write')`
+          rather than enumerating roles. Keep the permission→role map tiny and
+          data-driven for the MVP.
+      APPLY IT: every existing admin router requires AT LEAST the base `admin`
+      role (i.e. `require_role('admin')`, satisfied by `admin` and `super_admin`;
+      `read_only` passes only on read/GET endpoints). Reserve `require_role(
+      'super_admin')` for a couple of SENSITIVE operations as a worked example
+      (e.g. destructive deletes / bulk exports) — do not gate everything finely
+      yet; start COARSE.
+
+      (4) SAFE ROLLOUT BEHIND A FLAG. Gate enforcement behind a config flag
+      `RBAC_ENABLED` (default **OFF**). When OFF, behaviour is exactly as today
+      (any authenticated Entra admin is allowed) so nobody is locked out before
+      Azure AD App Roles are provisioned and assigned. When ON, `require_role`
+      enforces. Document and follow the enable sequence:
+        (a) provision the App Roles in the Entra app registration →
+        (b) assign roles to admin users/groups →
+        (c) verify tokens now carry the expected `roles` claim →
+        (d) flip `RBAC_ENABLED=on`.
+      Both `AUTH0_*` and `RETTX_ENTRA_*` remain REQUIRED config; add
+      `RBAC_ENABLED` alongside the existing settings.
+
+      (5) ENFORCEMENT IS SERVER-SIDE AND AUDITABLE. Authorization failures return
+      403 with a stable machine code (e.g. `code: insufficient-role`) and are
+      audited (actor = admin id, attempted operation, decision) with NO PHI /
+      identifiers only, consistent with Principle VI. Client gating (spec 042 /
+      rettxadmin) is UX only and is NEVER the control.
+
+      Tests: `require_role` 403s when `RBAC_ENABLED` on and the claim lacks the
+      role; allows when the claim has it; `super_admin` satisfies any check;
+      `read_only` blocked on writes, allowed on reads; with `RBAC_ENABLED` off
+      all authenticated admins pass (parity with today); missing `roles` claim ⇒
+      no roles (not admin); `get_user_info()` no longer returns a hardcoded
+      `is_admin=True`.
+
+  - repo: rettxadmin
+    summary: |
+      CONSUMER (UX only — the API is the security boundary; never rely on the
+      client for authorization). Build on the config-driven shell from
+      [spec 042](../042-admin-app-shell/spec.md). Keep the identity plane on
+      **Microsoft Entra / MSAL**; Auth0 is out of scope.
+
+      (1) EXPOSE ROLES INTO AUTH STATE. Read the Entra `roles` claim from the
+      MSAL account/ID-or-access token and surface it in the app's auth state
+      (e.g. a `roles: string[]` signal/observable on an auth/identity service).
+      Handle the empty/absent claim as "no roles".
+
+      (2) ROLE-BASED ROUTE GUARD. Add a `roleGuard` (canActivate) that blocks
+      routes the current roles cannot access, redirecting to a safe landing
+      (Overview) or a friendly "not authorised" state. This LAYERS ON TOP of the
+      existing `MsalGuard` (authentication) — auth first, then role.
+
+      (3) MENU GATING VIA THE 042 EXTENSION POINT. Consume the `requiredRoles`
+      slot already defined on `AdminNavItem` (spec 042): hide or disable sidenav
+      items the current roles cannot use, so the menu reflects the user's access.
+      Map the MVP roles (`super_admin`, `admin`, `read_only`) to items; e.g.
+      sensitive/destructive actions surface only for `super_admin`, `read_only`
+      sees view-oriented items, `admin` sees the standard set.
+
+      (4) UX-ONLY, RESTATED. Hiding a menu item or blocking a route is a
+      convenience, not a control: the API enforces every decision server-side
+      and returns 403 regardless of the client. Do NOT implement any logic that
+      assumes the client is the gate. Surface a clear message when the API
+      returns 403 (role insufficient) so the user understands, rather than a
+      silent failure.
+
+      Tests: a `read_only` identity cannot navigate to a write route and does not
+      see write-only menu items; an `admin` sees the standard set; `super_admin`
+      sees sensitive items; role state derives from the MSAL `roles` claim; the
+      guard composes correctly with `MsalGuard`.
+---
+
+# rettX Admin — RBAC MVP with Entra App Roles as the source of truth
+
+## Problem
+
+`rettxadmin` has **authentication but no authorization**. Every route is guarded
+by `MsalGuard` (are you signed in via Entra?) and nothing more. On the backend,
+`rettxapi` has **no RBAC at all**: `app/authentication/entra_client.py`
+`get_user_info()` **hardcodes `is_admin=True`** and the real roles-claim check
+(`is_admin = payload.get('roles', []) == ["admin"]`) is **commented out**. The
+`Principal` model carries only account-lifecycle `status`
+(`PROVISIONAL`/`ACTIVE`/`LOCKED`) — no role field — and admins are Entra
+principals who may not have a `Principal` record at all.
+
+The result: any authenticated Entra admin has full, undifferentiated access, and
+there is no way to distinguish an owner, an operator, and a read-only auditor.
+This spec introduces a **thin RBAC MVP** with a clear, single source of truth and
+a safe rollout.
+
+## Identity plane & source of truth
+
+- Admin/staff authenticate via **Microsoft Entra ID (MSAL)**. `rettxapi` admin
+  endpoints trust **Entra tokens only** (`require_admin` → `get_admin_id` →
+  `EntraClient`, `auth_provider="entra"`). Admin **stays on Entra** — we do not
+  migrate admin to Auth0 (that would break backend admin trust).
+- **Entra App Roles are the source of truth for admin authorization.** Roles are
+  delivered in the verified token **`roles` claim**. This is decided and
+  justified in
+  **[ADR 0012 — Admin RBAC via Entra App Roles](../../docs/adr/0012-admin-rbac-entra-app-roles.md)**
+  (a DB-driven `Principal.role` is rejected because admins may have no
+  `Principal` record and it splits the identity source of truth).
+
+## MVP role set (thin, and why)
+
+| Role | Grants | Persona |
+|---|---|---|
+| `super_admin` | Everything, including sensitive/destructive ops and future role/config management; superset of all checks | Owner / break-glass |
+| `admin` | The base admin role: all existing admin endpoints (today's behaviour, made explicit) | Standard operator |
+| `read_only` | View admin data; no mutations | Auditor / support |
+
+Three roles cover the real personas (owner, operator, viewer) without
+over-modelling permissions before concrete separation-of-duty needs exist. Finer
+permissions extend the **same** `roles` claim later — no re-architecture.
+
+## Enforcement (rettxapi — owner, the security boundary)
+
+- **Read the claim, don't fake it.** `get_user_info()` stops returning a
+  hardcoded `is_admin=True`; it extracts the `roles` claim from the
+  already-verified Entra token and surfaces `UserInfo.roles: list[str]`
+  (`is_admin` kept as a derived "has base admin role").
+- **Reusable dependency** in `app/dependencies/admin_permissions.py`, layered on
+  `get_admin_id`: `require_role(*roles)` (and optionally
+  `require_permission(perm)`), with `super_admin` implicitly satisfying any
+  check. Applied so **every** admin router needs at least `admin`; `read_only`
+  passes only on reads; a couple of **sensitive** ops require `super_admin` as a
+  worked example. Start **coarse**.
+- **Failures** return `403` with a stable code (e.g. `insufficient-role`) and are
+  **audited** (actor, operation, decision — identifiers only, no PHI).
+
+## Safe rollout — `RBAC_ENABLED`
+
+Enforcement is gated behind a config flag `RBAC_ENABLED`, **default OFF**, so
+turning on roles cannot lock everyone out before Azure AD App Roles are
+provisioned and assigned.
+
+Enable sequence:
+
+1. Provision the App Roles in the Entra app registration.
+2. Assign roles to admin users / groups.
+3. Verify issued tokens now carry the expected `roles` claim.
+4. Flip `RBAC_ENABLED=on`.
+
+With the flag **off**, behaviour matches today (any authenticated Entra admin is
+allowed). With it **on**, `require_role` enforces. `AUTH0_*` and `RETTX_ENTRA_*`
+remain required; `RBAC_ENABLED` is added alongside.
+
+## Client (rettxadmin — consumer, UX only)
+
+- Expose the Entra `roles` claim from MSAL into auth state (`roles: string[]`).
+- Add a `roleGuard` (layered on `MsalGuard`) that blocks routes the role can't
+  access.
+- Gate the sidenav by consuming the **`requiredRoles`** slot defined on
+  `AdminNavItem` in [spec 042](../042-admin-app-shell/spec.md); hide/disable
+  items the role cannot use.
+- **This is UX only.** The API enforces server-side and returns 403 regardless.
+  Surface 403s clearly rather than failing silently.
+
+## Non-goals
+
+- No migration of admin to Auth0; no change to Entra-only admin trust.
+- No DB-driven `Principal.role`; no change to `Principal.status` semantics
+  (lifecycle, not authz).
+- No fine-grained permission matrix in the MVP — start with three roles on one
+  claim; extend later.
+- No client-side authorization as a control — the client only reflects access.
+
+## Constitution Check
+
+- **Principle VI (Security baseline):** authorization is enforced **server-side**
+  on every admin endpoint via `require_role`; UI gating is explicitly a
+  usability nicety, not a control. Decisions are auditable (actor, operation,
+  outcome) with no PII in logs. Identity stays on federated Entra with
+  short-lived tokens.
+- **Least privilege:** the default posture is "no roles ⇒ no admin"; the flagged
+  rollout prevents accidental lock-out while moving from "everyone" to
+  role-scoped access; `read_only` enables view-without-mutate for auditors.
+- **Principle III (Transparency) / Governance:** the authorization model is
+  recorded in [ADR 0012](../../docs/adr/0012-admin-rbac-entra-app-roles.md) and
+  [patterns.md §4](../../.specify/memory/patterns.md), not left implicit in code.
+- **Patterns §4 (Authentication & authorization):** admin stays on Entra;
+  authorization is always server-side.
+
+## Acceptance criteria
+
+- [ ] `get_user_info()` no longer hardcodes `is_admin=True`; it reads the Entra
+      `roles` claim and exposes `UserInfo.roles: list[str]`.
+- [ ] `require_role(*roles)` (and optional `require_permission`) exists in
+      `app/dependencies/admin_permissions.py`, layered on `get_admin_id`, with
+      `super_admin` satisfying any check.
+- [ ] All existing admin routers require at least the base `admin` role;
+      `read_only` passes on reads only; ≥1 sensitive op requires `super_admin`.
+- [ ] Enforcement is gated by `RBAC_ENABLED` (default OFF); with it OFF,
+      behaviour equals today (no lock-out); with it ON, roles are enforced.
+- [ ] Authorization failures return 403 with a stable code and are audited (no
+      PHI).
+- [ ] rettxadmin exposes the `roles` claim into auth state, adds a `roleGuard`
+      layered on `MsalGuard`, and gates the sidenav via the spec 042
+      `requiredRoles` slot.
+- [ ] Client gating is UX only; 403s from the API are surfaced clearly; no
+      client logic assumes it is the security control.
+- [ ] No Auth0 in admin; no `Principal.role`; `Principal.status` unchanged.
+
+## Open questions
+
+- **Permission granularity:** ship pure role checks for the MVP, or introduce a
+  thin `require_permission` map now? (Recommend: roles only, with
+  `require_permission` as an optional convenience wrapper over the same roles.)
+- **Group vs. user assignment:** assign App Roles to Azure AD **groups** or
+  directly to **users**? (Ops decision — groups scale better; capture in the
+  rollout runbook.)
+- **`read_only` scope:** does `read_only` see every read endpoint, or a curated
+  subset? (Recommend: all GETs for the MVP; curate later if needed.)
+
+## Relationships
+
+- Pairs with **[spec 042 — Admin app shell](../042-admin-app-shell/spec.md)**,
+  which defines the `requiredRoles` nav extension point this spec consumes.
+- Decision record: **[ADR 0012 — Admin RBAC via Entra App Roles](../../docs/adr/0012-admin-rbac-entra-app-roles.md)**.
+- Conventions: **[patterns.md §4](../../.specify/memory/patterns.md)**
+  (auth/authz, server-side enforcement) and §2 (role vocabulary).


### PR DESCRIPTION
## Summary

Cross-cutting **control-plane** deliverables for the rettX admin app maturity program. **Markdown only** — no application code; no downstream repos touched. Both specs are `status: draft`, so **nothing fans out via Iris on merge** (draft status and PR-draft state are independent — this PR is non-draft for review).

## Deliverables

- **`specs/042-admin-app-shell/spec.md`** (`status: draft`) — dedicated gated MSAL/Entra login screen + a config-driven **left sidenav** (`MatSidenavModule`) replacing the hardcoded top toolbar: typed nav config, logical groups, Material Icons, responsive (persistent desktop / hamburger mobile), i18n-ready labels, and an **optional `requiredRoles` nav extension point** (defined only — no role logic). Fanout: **rettxadmin** only. Auth0 explicitly out of scope; MSAL/Entra throughout.
- **`specs/043-admin-rbac-mvp/spec.md`** (`status: draft`) — thin admin RBAC with **Entra App Roles** (`roles` claim) as source of truth. rettxapi: stop hardcoding `is_admin=True`, surface `UserInfo.roles`, add `require_role`/`require_permission` in `app/dependencies/admin_permissions.py`, gate behind **`RBAC_ENABLED`** (default OFF). rettxadmin: expose the claim, add a role guard, consume 042's `requiredRoles` (UX only). Roles: `super_admin` / `admin` / `read_only`. Fanout: **rettxapi + rettxadmin**.
- **`docs/adr/0012-admin-rbac-entra-app-roles.md`** (Proposed) — Entra App Roles as admin authz source of truth; rejects DB `Principal.role`, static email allow-list, Auth0 migration, and client-only gating.
- **`.specify/memory/patterns.md`** — §2 admin RBAC vocabulary, §4 server-side admin authz, §11 changelog.

## Ground truth honoured

- Two deliberate identity planes: **admin → Entra/MSAL**, caregivers → Auth0. Admin **stays on Entra** (backend trusts Entra tokens only). No Auth0 migration proposed anywhere.
- Grounded on the live `rettxadmin` route table and the current `rettxapi` Entra/Principal reality (hardcoded `is_admin`, no `Principal.role`).

## Notes

- Cross-links wired: 042 ↔ 043, both ↔ ADR 0012, all ↔ patterns.md. All relative links verified resolving on disk.
- Each spec includes a **Constitution Check** (Principles V, VI) section.
- Numbering avoids the reserved 041 / ADR 0011 (in-flight PR #46).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>