### PR TITLE
docs(spec): 046 — change_reason is immutable, corrections are metadata

### DIFF
--- a/docs/adr/0015-medication-regimen-not-pulse-event.md
+++ b/docs/adr/0015-medication-regimen-not-pulse-event.md
@@ -75,8 +75,9 @@ Specifics:
    versioning pattern already proven in the catalog, partitioned `/patient_id` so
    an **"as of date D"** read is a cheap single-partition query. Correcting a
    mis-typed row is the one in-place write, and is explicitly distinguished from
-   a clinical change in both the contract (`change_reason: "corrected"`) and the
-   UI.
+   a clinical change in both the contract and the UI. A correction records
+   `corrected_at` / `corrected_by` and **never rewrites `change_reason`** — see
+   decision 13.
 3. **Daily medication logging is replaced by exception events.** A missed, extra
    or changed dose is recorded as an ordinary **Pulse tracker entry** under a new
    `medication-exception` definition that references the opaque `medication_id`
@@ -179,6 +180,20 @@ Specifics:
     that the dose ever was 300 mg, so a later seizure spike is attributed to the
     wrong exposure. Corrections are audited but stay out of the caregiver-facing
     treatment history, which is a story of the treatment, not of the typing.
+
+    **`change_reason` is immutable, and there is no `corrected` value in it.** An
+    earlier draft of the contract had a correction rewrite `change_reason` to
+    `corrected`, which quietly reintroduced the second failure above: correct a
+    typo in a version that recorded a genuine prescribed dose change, and that
+    version stops saying a dose change ever happened. Any client honouring "keep
+    corrections out of the history" by filtering on `change_reason` — the obvious
+    implementation — would then erase a real change from the caregiver's history
+    and drop its marker from the before/after panel. One field was carrying two
+    orthogonal facts: *what clinical event this version is*, which is immutable,
+    and *whether the record was later amended*, which is bookkeeping. They are now
+    separate: a correction sets `corrected_at` / `corrected_by` and touches
+    nothing else. This also removes the need to filter at all — a correction
+    creates no version, so nothing about it is in the history to begin with.
 
 ## Consequences
 

--- a/specs/046-medication-regimen/contracts/medication-regimen-api.md
+++ b/specs/046-medication-regimen/contracts/medication-regimen-api.md
@@ -45,14 +45,18 @@ mcg | mg | g | ml | drop | sachet | tablet | capsule | puff | IU
 
 Units are **advisory, not clinically validated** — rettX does not judge doses.
 
-**Change reasons** (why a new version exists):
+**Change reasons** (why a new version exists) — **immutable once written**:
 
 ```
-started | dose-changed | stopped | restarted | corrected
+started | dose-changed | stopped | restarted
 ```
 
-`corrected` is the only reason that means "the previous version was wrong",
-as opposed to "the treatment changed". Clients MUST surface the difference
+Every value names a **clinical event**. There is deliberately no `corrected`
+value: a correction is bookkeeping about the record, not something that happened
+to the patient, and it creates no new version. Corrections are recorded on the
+amended version as `corrected_at` / `corrected_by` and MUST NOT rewrite
+`change_reason` — see `PATCH .../versions/{version}` for why. Clients MUST
+surface the difference between a prescribed change and a correction
 (spec FR-018).
 
 ## Resource shape
@@ -72,11 +76,15 @@ as opposed to "the treatment changed". Clients MUST surface the difference
   "instructions": null,                  // free text — POTENTIAL PHI (FR-014)
   "valid_from": "2026-07-20",           // REQUIRED
   "valid_to": null,                      // null = still taking
-  "change_reason": "dose-changed",
+  "change_reason": "dose-changed",       // IMMUTABLE — the clinical event this
+                                         // version records. A later correction
+                                         // NEVER rewrites it.
   "is_current": true,                    // latest version for this medication_id
   "superseded_by": null,                 // version number, when superseded
   "created_at": "2026-07-20T09:14:00Z",
   "created_by": "<principal-id>",
+  "corrected_at": null,                  // set when this version was amended
+  "corrected_by": null,                  // in place; null = never corrected
   "_etag": "\"0x8DC...\""
 }
 ```
@@ -200,6 +208,10 @@ dates in the gap.
 - an unknown slot or unit code
 - `amount_max ≤ amount`
 - a `time` that is not a valid `HH:MM` 24-hour wall-clock value
+- a `change_reason` outside the enum — including the literal string `corrected`,
+  which is not a clinical event and MUST be rejected rather than silently stored
+- a request body attempting to set `corrected_at` or `corrected_by`; both are
+  server-assigned by `PATCH .../versions/{version}` and are never client input
 
 Explicitly **not** rejected: a `time` that looks inconsistent with its slot
 (e.g. `07:00` in `evening`). Caregivers have reasons, and policing this would
@@ -209,10 +221,30 @@ No clinical validation of any kind.
 
 ### `PATCH .../versions/{version}`
 
-Corrects a mistake **in place** (`change_reason` becomes `corrected`). Requires
-`If-Match` with the version's `_etag`. This is the only write that changes an
-existing version's values, and clients MUST present it distinctly from a
-clinical change (FR-018).
+Corrects a mistake **in place**. Requires `If-Match` with the version's `_etag`.
+This is the only write that changes an existing version's values, and clients
+MUST present it distinctly from a clinical change (FR-018).
+
+**A correction MUST NOT rewrite `change_reason`.** It sets `corrected_at` and
+`corrected_by` and leaves every other piece of the version's clinical identity
+intact. There is no `corrected` value in the `change_reason` enum, and servers
+MUST NOT invent one.
+
+The reason is worth stating, because the obvious design fails. `change_reason`
+records **what clinical event this version is** — started, dose-changed, stopped,
+restarted. Whether it was later corrected is **bookkeeping about the record**,
+not a clinical event. Overwriting the first with the second destroys
+information: correct a typo in a version that recorded a genuine prescribed dose
+change, and that version stops saying a dose change happened. Any client
+honouring "corrections stay out of the treatment history" by filtering on
+`change_reason` would then erase a real prescribed change from the caregiver's
+history and drop its marker from the Insights before/after panel — the precise
+failure FR-018 exists to prevent.
+
+Keeping the two separate also removes the need to filter anything: a correction
+creates **no new version**, so nothing about it belongs in the treatment history
+to begin with. Clients MAY surface `corrected_at` as quiet provenance on the
+version it amended; they MUST NOT render it as a treatment change.
 
 ### `DELETE /v2/patients/{rettxid}/pulse/medications/{medication_id}`
 

--- a/specs/046-medication-regimen/spec.md
+++ b/specs/046-medication-regimen/spec.md
@@ -358,6 +358,14 @@ gap analysis in `rettxapi` and `rettxweb` (same day).
   300 mg, so a later seizure spike is attributed to the wrong dose. Corrections
   MUST be audited (FR-012) but MUST NOT appear in the caregiver-facing treatment
   history, or the story of a treatment becomes a list of typos.
+  **`change_reason` is immutable and has no `corrected` value** — a correction
+  records `corrected_at` / `corrected_by` and rewrites nothing else. An earlier
+  draft had corrections overwrite `change_reason`, which reintroduced the second
+  failure above: correcting a typo in a version that recorded a real prescribed
+  change made that version stop saying a change had happened, so any client
+  filtering on `change_reason` would erase it from both the history and the
+  Insights markers. It also means there is nothing to filter — a correction
+  creates no version, so it is absent from the history by construction.
 - **D4 — Retire, don't migrate.** Existing pilot medication entries stay in
   place, read-only, and keep rendering; the preset is retired; regimens start
   empty and caregivers enter their current sheet once. *Rationale:* a best-effort
@@ -791,6 +799,13 @@ label; the medication metric no longer appears in the loggable metric picker.
   writes a new version and preserves the previous one; and **correcting something
   the caregiver entered wrongly**, which does not invent a clinical event. The UI
   MUST make the two unmistakable at the point of editing.
+- **FR-018a** A correction MUST NOT alter `change_reason`, which records the
+  clinical event a version represents and is immutable once written. A correction
+  sets `corrected_at` / `corrected_by` only. Clients MAY show that a version was
+  corrected as quiet provenance on the version itself; they MUST NOT render it as
+  a treatment change, and MUST NOT rely on `change_reason` to exclude corrections
+  from the treatment history — corrections create no version, so nothing about
+  them is in that history to exclude.
 - **FR-019** The client MUST produce a **one-page A4 PDF medication sheet**
   entirely **on-device**, from a single layout implementation used on every
   surface, containing: the as-of date, the latest known weight and height with


### PR DESCRIPTION
Found while reviewing rettxweb#282, which implemented the contract faithfully. The defect is in the contract, not that PR.

## The problem

The contract said a correction makes `change_reason` **become** `corrected`. Follow it through:

1. `v2` records a genuine prescribed dose change on 1 March — 50 mg → 75 mg.
2. The caregiver later notices they typed 75 mg when the doctor said 70 mg, and corrects `v2` in place.
3. `v2.change_reason` is now `corrected`. **The fact that a prescribed dose change happened on 1 March is gone.**

D14 requires corrections to stay out of the caregiver-facing treatment history. The obvious way any client implements that is by filtering on `change_reason === 'corrected'` — which would then **erase a real prescribed change from the treatment history** and drop its marker from the Insights before/after panel, so a genuine dose change stops being analysed.

That is the exact failure ADR 0015 decision 13 says the design exists to prevent: *"A change misfiled as a correction erases that the dose ever was 300 mg, so a later seizure spike is attributed to the wrong exposure."* The contract manufactured the bug it was written to avoid.

**Root cause:** one field carrying two orthogonal facts — *what clinical event this version represents* (immutable) and *whether the record was later amended* (bookkeeping).

## The change

`change_reason` records only the clinical event and is immutable. Corrections set `corrected_at` / `corrected_by` and rewrite nothing else.

This makes clients **simpler**, not more complex: because a correction creates no version, there is nothing to filter out of the treatment history. Corrections are absent by construction. The old design forced every client to implement an exclusion rule, and the obvious implementation of that rule was the bug.

- **contract** — enum drops `corrected` and is marked immutable; `corrected_at` / `corrected_by` added to `MedicationRegimenRow`; `PATCH .../versions/{version}` states the rule and the reasoning; two new `422` cases — a `corrected` change_reason must be rejected rather than silently stored, and the correction fields are server-assigned, never client input
- **spec** — D14 extended; new **FR-018a** forbidding clients from using `change_reason` to exclude corrections
- **ADR 0015** — decision 13 records the rejected draft and why, so the field split doesn't later look arbitrary

## Timing

rettxapi has not started slice 1.2, so the server model does not exist yet and this costs nothing there. rettxweb#282 needs a small edit (drop `'corrected'` from the union, add `correctedAt`/`correctedBy`, stop overwriting `changeReason` in the mock) — already instructed, to be made on the existing PR.

## Notes

- Frontmatter re-validated with the workflow's own regex + `yaml.safe_load`; both fanout entries intact.
- `spec-fanout` is idempotent by issue title, so it will not refresh rettxapi#365 or rettxweb#281 — the delta will be relayed by comment after merge, as with #54.