### PR TITLE
docs(agents): write down the drill instead of rediscovering it

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,6 +11,7 @@ application code repository.
 - Architectural Decision Records (`docs/adr/`)
 - Public documentation site source (`site/`, Astro Starlight)
 - Issue intake & routing automation (`.github/workflows/`)
+- Delivery accounting (`scripts/status.mjs`, `patterns.md` §11)
 
 ## What this repo is NOT for
 
@@ -27,7 +28,13 @@ application code repository.
 ## Working in this repo
 
 - Prefer markdown changes over code. The only "code" here is GitHub
-  Actions workflows and small helper scripts under `scripts/iris/`.
+  Actions workflows and small helper scripts under `scripts/`.
+- **Ask `scripts/status.mjs` before answering "what's the status?"** It
+  reconciles specs here against open squad issues and pull requests in the
+  five downstream repos. Do not assemble a programme picture by hand or from
+  memory — that is how it goes stale. Output is written to `status.local.md`,
+  which is gitignored and must never be committed or quoted here (it contains
+  private repo titles). The script refuses to run in CI for the same reason.
 - When proposing or implementing a cross-cutting feature, scaffold a new
   spec under `specs/NNNN-slug/` based on `specs/template/`.
 - When making an architectural decision that affects more than one repo,
@@ -40,13 +47,70 @@ application code repository.
 
 If a task here implies changes in `rettxweb`, `rettxadmin`, `rettxapi`,
 `rettxmutation`, or `rettxid`, **do not edit those repos directly from
-this repo's context**. Instead:
+this repo's context** — and do not run commands inside a downstream
+checkout, which may be a live working tree someone is using. Instead:
 
 1. Capture the change in a cross-cutting spec under `specs/`.
 2. Once merged, the `spec-fanout` workflow opens scoped issues in the
    affected repos (label: `squad`).
 3. A maintainer picks up each fan-out issue by spawning an orchestrated
    working session in that repo (one session → one branch → one PR).
+
+Urgent production breakage does not wait for a spec — that is what the
+`incident` lane is for (`patterns.md` §11). It ships without a spec, keeps its
+scope at the fix, and is reconciled within 7 days. Do **not** improvise a
+different route, and do **not** write a spec afterwards and present existing
+work as though the spec had driven it.
+
+## The drill — operational facts, not discoveries
+
+These are settled properties of this repo and its ecosystem. Read them once;
+do not rediscover them, and do not report them back as findings.
+
+**`main` is protected here and in every downstream repo.** Rules: `pull_request`
+required, `non_fast_forward`, no `deletion` (downstream repos add
+`copilot_code_review`). So: branch first, always. A direct commit to `main` is
+rejected with `GH013` *after* the work is done and then has to be moved onto a
+branch. Run `git checkout -b <name>` before the first edit, never after.
+
+**This repo is PUBLIC. `rettxweb`, `rettxadmin`, `rettxapi`, `rettxmutation`
+and `rettxid` are PRIVATE.** Anything that lands here — files, PR bodies, commit
+messages, issue comments, and **GitHub Actions logs and job summaries** — is
+world-readable. Never paste private-repo issue or PR titles, code, telemetry
+output, or infrastructure detail into this repo. Actions logs are the
+non-obvious leak: a workflow here that merely *reads* private repos publishes
+whatever it prints.
+
+**No CI runs on spec PRs.** Only `iris-route` and `spec-fanout` trigger on
+`pull_request`, and neither validates spec content. `gh pr checks` reporting
+"no checks reported" is normal, not a failure. Frontmatter correctness is your
+responsibility before merge; nothing will catch it for you.
+
+**Fan-out is driven by `status:`.** A spec with `status: draft` fans out
+nothing, however finished it looks. Only `ready` or `accepted` opens squad
+issues, and only on merge. Merging a draft spec is safe and is the normal way
+to iterate in the open.
+
+**Attribute work by declaration, never inference.** Every downstream PR carries
+a `Spec:` line (`patterns.md` §11). Do not infer a spec from prose — a passing
+mention of "(spec 042)" is not a declaration, and treating it as one mis-files
+the work.
+
+## Tooling gotchas that cost time
+
+- **`gh label list --search <term>` returns nothing even when the label
+  exists.** Use `gh label list --limit 200 --json name` and filter. A blank
+  `--search` result looks exactly like a missing label.
+- **Resolve a PR's head before reviewing or reporting on it**:
+  `gh pr view <n> --json headRefOid`. Local `HEAD`, the remote branch and the
+  PR can all disagree; a report written against a stale head is worse than no
+  report.
+- **PowerShell has no heredoc.** For multi-line commit messages use a
+  single-quoted here-string (`@'` … `'@`) written to a file, then
+  `git commit -F <file>`.
+- **Verify a mutation actually landed before trusting a test result.** A failed
+  string replacement leaves the source unchanged, the suite passes, and the
+  "proof" is worthless. Assert the edit is present, then run.
 
 ## Style
 

--- a/scripts/status.mjs
+++ b/scripts/status.mjs
@@ -302,8 +302,9 @@ const incidents = prs.filter(p => p.slug === 'incident' || hasIncidentLabel(p));
 
 say('## Incidents awaiting reconciliation');
 say('');
-say(`Shipped under the incident lane. Each owes a spec — or a recorded decision to`);
-say(`close it as a one-off — within ${INCIDENT_RECONCILE_DAYS} days.`);
+say('**Open pull requests** labelled `incident` — shipped without a spec because');
+say(`production was broken. Each owes a spec, or a recorded decision to close it as`);
+say(`a one-off, within ${INCIDENT_RECONCILE_DAYS} days.`);
 say('');
 if (!incidents.length) {
   say('_None open._');
@@ -311,7 +312,7 @@ if (!incidents.length) {
   for (const p of incidents.sort((a, b) => daysSince(b.createdAt) - daysSince(a.createdAt))) {
     const age = daysSince(p.createdAt);
     const flag = age > INCIDENT_RECONCILE_DAYS ? ' **← OVERDUE**' : '';
-    say(`- \`${p.repo}#${p.number}\` — ${short(p.title)} _(${age}d old)_${flag}`);
+    say(`- PR \`${p.repo}#${p.number}\` — ${short(p.title)} _(${age}d old)_${flag}`);
   }
 }
 say('');
@@ -334,15 +335,17 @@ const depPrs = prs.filter(p => isDepBot(p));
 
 say('## Downstream work with no spec declared');
 say('');
-say('Attribution is by explicit declaration only — a `Spec:` line, a `[spec/<slug>]`');
-say('title, or a closing keyword aimed at a fan-out issue. Nothing here is guessed,');
-say('so this list is the true set of work the control plane cannot account for.');
+say('**Open pull requests** in the private downstream repos that do not say which');
+say('spec they serve. Attribution is by explicit declaration only — a `Spec:` line,');
+say('a `[spec/<slug>]` title, or a closing keyword aimed at a fan-out issue. Nothing');
+say('here is guessed, so this is the true set of work the control plane cannot');
+say('account for.');
 say('');
 if (!undeclared.length) {
   say('_None._');
 } else {
   for (const p of undeclared.sort((a, b) => daysSince(b.updatedAt) - daysSince(a.updatedAt))) {
-    say(`- \`${p.repo}#${p.number}\`${p.isDraft ? ' _(draft)_' : ''} — ${short(p.title)} _(${daysSince(p.updatedAt)}d quiet)_`);
+    say(`- PR \`${p.repo}#${p.number}\`${p.isDraft ? ' _(draft)_' : ''} — ${short(p.title)} _(${daysSince(p.updatedAt)}d quiet)_`);
   }
   say('');
   say('Add `Spec: <id>` — `Spec: none — <reason>` for maintenance, or');


### PR DESCRIPTION
Every session has been relearning the same operational facts and then reporting them back as findings — that `main` is protected, that no CI runs on spec PRs, that `gh label list --search` returns nothing even when the label exists.

None of those are insights. They are settled properties of the repo, and dressing them up as discoveries wastes attention and buries the findings that actually matter.

## What it records

All verified against the live repos rather than asserted:

- **`main` is protected here and downstream** (`pull_request`, `non_fast_forward`, no `deletion`; downstream adds `copilot_code_review`). Branch before the first edit — a direct commit is only rejected *after* the work is done, and then has to be moved.
- **This repo is PUBLIC, the five downstream repos are PRIVATE** — including the non-obvious vector: Actions logs and job summaries here are world-readable, so a workflow that merely *reads* a private repo publishes whatever it prints.
- **No CI runs on spec PRs.** Only `iris-route` and `spec-fanout` trigger on `pull_request`, and neither validates spec content. "No checks reported" is normal; frontmatter correctness is nobody else's job.
- **Fan-out is gated on `status:`** — merging a `draft` spec is safe.
- **Attribution is by declaration, never inferred from prose.**

Plus four tooling gotchas that have each cost real time: the `gh label list --search` trap, resolving a PR head before reporting on it, PowerShell's lack of heredoc, and verifying a mutation actually landed before trusting a test result.

## Two stale lines corrected

Helper scripts are no longer only under `scripts/iris/`, and the cross-repo section now names the `incident` lane — so urgent work has a route that doesn't have to be improvised, with the explicit instruction **not** to write a spec afterwards and present existing work as though the spec had driven it.

Spec: none — agent instructions for this repo.
