### PR TITLE
fix(status): say how long a draft spec has been sitting

### DIFF
--- a/.specify/memory/patterns.md
+++ b/.specify/memory/patterns.md
@@ -494,6 +494,14 @@ earlier draft guessed from surrounding text and mis-filed a spec-036 pull
 request under spec 042 on the strength of an incidental mention; a ledger that
 guesses is worse than one that admits what it cannot account for.
 
+Drafts are listed **oldest-edited first**, with their age in days, and flagged
+once untouched for 21+ days. A draft being argued over is healthy; a draft
+nobody has touched in weeks is the real failure mode, and only age separates
+them. Spec 034 sat in `draft` for three weeks while the problem it described
+recurred, and nothing in the programme noticed. The age comes from git rather
+than from a date the author has to remember to write down, so it cannot itself
+go stale. It is a prompt, never a gate.
+
 **It is a local script and must never become a workflow in this repo.** `rettx`
 is public; the five downstream repos are private, and the report carries their
 issue and pull-request titles, which describe unfixed weaknesses in a codebase

--- a/scripts/status.mjs
+++ b/scripts/status.mjs
@@ -115,6 +115,24 @@ function frontmatter(text) {
   };
 }
 
+// When a spec was last edited. A draft that is being argued over is healthy; a
+// draft nobody has touched in weeks is the 034 failure — authored, correct, and
+// silently going nowhere. Age is what tells those two apart, so the report has
+// to carry it. Returns null rather than throwing if git can't answer (shallow
+// clone, or the spec is not committed yet), and the caller just omits the age.
+function lastTouched(dir) {
+  try {
+    const out = execFileSync('git', ['log', '-1', '--format=%cI', '--', dir], {
+      cwd: root,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    }).trim();
+    return out || null;
+  } catch {
+    return null;
+  }
+}
+
 function loadSpecs() {
   if (!fs.existsSync(specsDir)) return [];
   return fs
@@ -125,7 +143,7 @@ function loadSpecs() {
       if (!fs.existsSync(file)) return null;
       const fm = frontmatter(fs.readFileSync(file, 'utf8'));
       if (!fm || !fm.slug) return null;
-      return { dir: d.name, ...fm };
+      return { dir: d.name, touched: lastTouched(path.join('specs', d.name)), ...fm };
     })
     .filter(Boolean)
     .sort((a, b) => String(a.spec_id).localeCompare(String(b.spec_id)));
@@ -267,7 +285,11 @@ if (!drift.length) {
 say('');
 
 // 2. Specs still awaiting a decision.
-const drafts = specs.filter(s => s.status === 'draft');
+// Sorted oldest-first: the drafts most likely to have been forgotten are the
+// ones you read first, rather than the ones with the lowest spec number.
+const drafts = specs
+  .filter(s => s.status === 'draft')
+  .sort((a, b) => (a.touched || '').localeCompare(b.touched || ''));
 say('## Waiting on a maintainer decision');
 say('');
 if (!drafts.length) {
@@ -275,12 +297,18 @@ if (!drafts.length) {
 } else {
   for (const s of drafts) {
     const o = openFor(s.slug);
-    say(`- **${s.spec_id} · ${s.slug}** — ${short(s.title, 70)}`);
+    const age = s.touched === null ? null : daysSince(s.touched);
+    const aged = age !== null && age >= staleDays;
+    say(`- **${s.spec_id} · ${s.slug}**${aged ? ' ⚠️' : ''} — ${short(s.title, 70)}`);
+    if (age !== null) {
+      say(`  - last edited ${age}d ago` + (aged ? ` — untouched for ${staleDays}+ days, so nothing is moving it` : ''));
+    }
     say(`  - \`draft\`, so it fans out nothing on merge` +
       (s.fanout.length ? ` (would route to: ${s.fanout.join(', ')})` : ''));
     if (o.prs.length) say(`  - ${o.prs.length} downstream PR(s) already open against it`);
   }
 }
+const agedDrafts = drafts.filter(s => s.touched !== null && daysSince(s.touched) >= staleDays);
 say('');
 if (specPrs.length) {
   say('Open spec PRs in the control plane:');
@@ -386,7 +414,7 @@ fs.writeFileSync(outPath, L.join('\n') + '\n', 'utf8');
 
 console.error('');
 console.error(`  drift:        ${drift.length} shipped spec(s) with delivery open`);
-console.error(`  decisions:    ${drafts.length} draft spec(s), ${specPrs.length} open spec PR(s)`);
+console.error(`  decisions:    ${drafts.length} draft spec(s)${agedDrafts.length ? ` (${agedDrafts.length} untouched ${staleDays}+d)` : ''}, ${specPrs.length} open spec PR(s)`);
 const overdue = incidents.filter(p => daysSince(p.createdAt) > INCIDENT_RECONCILE_DAYS).length;
 console.error(`  incidents:    ${incidents.length} open (${overdue} overdue)`);
 console.error(`  undeclared:   ${undeclared.length} downstream PR(s) with no spec declared`);

--- a/specs/049-unicorn-diagnostics-recovery/spec.md
+++ b/specs/049-unicorn-diagnostics-recovery/spec.md
@@ -681,12 +681,20 @@ raised as OD-6.
   support; a truncation is easier to read aloud.
 - **OD-5** Does rettxadmin have a fatal-error surface today, or does this create
   one? Determines whether its slice is small or merely tiny.
-- **OD-6** How does the programme surface a spec that is authored, correct and
-  **stalled**? Spec 034 sat in `draft` for three weeks while the incident it
-  described recurred. Options: a scheduled staleness report over `status: draft`
-  older than N days, a required decision-by date in frontmatter, or accepting it
-  as a purely human review habit. Out of scope for the unicorn work itself, but
-  it is the reason this spec had to re-derive ground 034 already covered.
+- **OD-6** ~~How does the programme surface a spec that is authored, correct and
+  **stalled**?~~ **Resolved 2026-08-04.** `scripts/status.mjs` now reports every
+  `draft` spec with the number of days since it was last edited, sorted
+  oldest-first, and flags any untouched for 21+ days. Run against this spec it
+  immediately named 034 at 22 days — the precise case that prompted the
+  question. Two rejected alternatives, recorded so they are not re-proposed: a
+  **scheduled workflow** cannot live here, because `rettx` is public and Actions
+  logs are world-readable, so a job reading the private repos would publish
+  their contents (patterns.md §11); and a **decision-by date in frontmatter**
+  puts the burden on the author at the moment they care least, and goes stale
+  silently exactly like the spec it is meant to police. Last-edited is derived
+  from git, so it cannot drift from reality or be forgotten. It is deliberately
+  a prompt to a human, not a gate: a draft under active argument is healthy, and
+  only silence is the signal.
 - **OD-7** What is an acceptable caregiver wait? The evidence establishes 30 s as
   a **safety floor** — roughly 14 s above the worst legitimate completion, so it
   will not kill healthy slow requests. It does not establish 30 s as a tolerable


### PR DESCRIPTION
The ledger listed draft specs but not their age — which left the one failure it was built to catch invisible.

Spec 034 sat in `draft` for three weeks while the problem it described kept recurring. The report would have shown it as a perfectly ordinary line item, sitting next to specs opened that morning.

## Change

Drafts now carry days-since-last-edit, sort **oldest-first** so the forgotten ones get read before the fresh ones, and are flagged once untouched for 21+ days.

Run against `main` it immediately names the right one:

```
- 034 · auth-observability ⚠️ — rettX Auth-Failure Observability & Diagnosability
  - last edited 22d ago — untouched for 21+ days, so nothing is moving it
- 045 · ios-app — rettX iOS App (Capacitor on GitHub Actions)
  - last edited 6d ago
- 049 · unicorn-diagnostics-recovery — The app must never trap a caregiver…
  - last edited 0d ago
```

## Why git, not frontmatter

Age comes from `git log` on the spec directory, not a `decision-by` date in frontmatter. A date written by the author is a promise made at the moment they care least about it, and it goes stale silently — exactly like the spec it is supposed to police. Git can't drift from reality.

It's a **prompt, not a gate**. A draft under active argument is healthy; only silence is a signal.

## Closes OD-6 in spec 049

The rejected alternatives are recorded in the spec so they don't get re-proposed — including a scheduled workflow, which can't live in this repo at all: `rettx` is public, Actions logs are world-readable, and a job reading the private repos would publish their contents.

## Verification

- Both fallbacks checked: an untracked path returns empty and the age line is omitted; running outside a git repo throws and is caught.
- `scripts/status.test.mjs` — 18/18 pass.

Spec: 049 — answers OD-6.
