### PR TITLE
docs(agents): specs state outcomes, not mechanisms

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -96,6 +96,16 @@ a `Spec:` line (`patterns.md` §11). Do not infer a spec from prose — a passin
 mention of "(spec 042)" is not a declaration, and treating it as one mis-files
 the work.
 
+**Specs state outcomes, not mechanisms.** A cross-cutting spec says what must be
+true and why; *how* a repo achieves it is that repo's decision, governed by its
+own constitution. Naming file paths, classes, build-tool invocations, config
+predicates or stack vendors in a spec is out of bounds twice over: it takes a
+decision that isn't this repo's to take, and it publishes private-codebase
+internals to a public repo. Reach for the mechanism only when the requirement
+genuinely is cross-cutting — "the build must fail if X is unset" belongs in a
+spec; which tool substitutes X does not. This applies to PR bodies and commit
+messages too, which are just as public as the file.
+
 ## Tooling gotchas that cost time
 
 - **`gh label list --search <term>` returns nothing even when the label


### PR DESCRIPTION
Caught myself authoring spec decisions that argued through downstream implementation detail — file paths, classes, build-tool invocations, a config predicate, a stack vendor. (Fixed in #65, which was rewritten before review.)

Two things wrong with that, and the second is the serious one.

**It takes a decision that isn't this repo's to take.** Each downstream repo owns its stack-level choices under its own constitution. A spec that names the mechanism has quietly made the choice on its behalf.

**It publishes private-codebase internals to a public repo.** `rettx` is public; the five app repos are not. The rule has to cover PR bodies and commit messages too — they're exactly as public as the file, and they're where the detail survives after the file gets cleaned up.

## Where the line is

Whether the requirement is genuinely cross-cutting.

> "The build must fail if the identity is not substituted" — **spec-level**. It's what turns an intention into an enforcement, and it holds whatever the stack.
>
> Which tool performs the substitution — **not**.

Spec: none — agent operating instructions.
