### PR TITLE
docs(spec): 049 ready, and fix multi-slice delivery accounting

### DIFF
--- a/.specify/memory/patterns.md
+++ b/.specify/memory/patterns.md
@@ -477,6 +477,26 @@ A `[spec/<slug>]` title prefix, or a closing keyword (`Closes #NNN`) aimed at a
 fan-out issue, counts as a declaration on its own — the fan-out issue already
 carries the slug.
 
+**Use a closing keyword only when the pull request completes the whole spec for
+that repo.** A fan-out issue is an umbrella: most specs land as several slices,
+and `Closes` on the first one to merge shuts the umbrella while the rest are
+still outstanding. The remaining slices then have nothing open to attach to, so
+the return path goes dark exactly when there is most left to deliver — and a
+half-delivered spec reads as shipped, which is one of the three failures this
+section exists to prevent.
+
+A slice therefore declares:
+
+```
+Spec: 049
+
+Part of #NNN — does not close it; further slices remain.
+```
+
+The `Spec:` line is the declaration; the bare issue reference supplies the link
+without closing. The last slice may use `Closes #NNN`, or the fan-out issue is
+closed by hand once the spec is delivered.
+
 `Spec: none` is a first-class answer, not a failure. The point is not that all
 work descends from a spec; it is that **unaccounted work is visible as such**.
 

--- a/specs/049-unicorn-diagnostics-recovery/spec.md
+++ b/specs/049-unicorn-diagnostics-recovery/spec.md
@@ -24,7 +24,7 @@
 spec_id: "049"
 slug: "unicorn-diagnostics-recovery"
 title: "The app must never trap a caregiver — fatal client errors and silent hangs"
-status: draft   # draft | ready | accepted | superseded
+status: ready   # draft | ready | accepted | superseded
 authored: "2026-08-04"
 author: "perocha"
 relates_to: "specs/034-auth-observability/ (origin of the `unicorn` term and of the per-install correlation id); .specify/memory/patterns.md §2 Operational shorthand (defines `unicorn`)"
@@ -734,26 +734,37 @@ raised as OD-6.
   from git, so it cannot drift from reality or be forgotten. It is deliberately
   a prompt to a human, not a gate: a draft under active argument is healthy, and
   only silence is the signal.
-- **OD-7 and OD-8 are coupled, and cannot be answered separately.** Recorded
-  2026-08-04. The slowest legitimate read yet measured has a tail extending well
+- **OD-7 and OD-8 are DEFERRED PENDING FR-018, not blocking.** Recorded
+  2026-08-04, when this spec was moved to `ready`. Neither can be answered from
+  the evidence that exists, and the instrument that would answer them is
+  FR-018 — which only gets built once this spec fans out. Holding the spec in
+  `draft` until they are settled therefore makes them permanently unanswerable.
+  That is exactly how spec 034 stalled, and repeating it here would reproduce
+  the failure this spec was written to explain. They are recorded as open
+  questions with provisional answers, and revisited at the 30-day review against
+  FR-018 data.
+- **OD-7 and OD-8 are coupled, and cannot be answered separately.** The slowest
+  legitimate read yet measured has a tail extending well
   beyond ten seconds. Any *uniform* bound must clear that, or it kills
   healthy requests. So "30 s is too long to ask a caregiver to wait" and "one
   bound for every read" **cannot both hold** — shortening the wait necessarily
   means per-class bounds. Answering either one in isolation silently decides the
   other.
-- **OD-7** What is an acceptable caregiver wait? Still open, and deferred **by
+- **OD-7** What is an acceptable caregiver wait? Deferred **by
   design rather than by neglect**: D9/FR-018 require instrumentation before
   enforcement, and the server-side evidence cannot answer this question, because
   it measures requests that completed rather than caregivers who gave up. 30 s
   stands as a **provisional safety floor** — explicitly not a settled answer to
   what a caregiver should be asked to tolerate. Revisit once FR-018 data exists,
   and record the number with its reason. Affects FR-022.
-- **OD-8** Uniform or per-class? Still open, but with one consequence already
-  settled: whichever is chosen, **FR-018 instrumentation MUST record enough
+- **OD-8** Uniform or per-class? Deferred on the same basis, with two things
+  already settled so that deferring costs nothing. First, **uniform is the
+  starting rule** — it matches the implementation already in flight, so no slice
+  is blocked waiting for this answer. Second, whichever is eventually chosen,
+  **FR-018 instrumentation MUST record enough
   per-route-class detail from the first day it ships**. If it does not, choosing
   per-class later means re-instrumenting and waiting out a second observation
-  window — so the cheap option now forecloses the better option later. Uniform
-  is the sensible starting rule, since it matches the implementation already in
-  flight; the scope/evidence mismatch (measurement covers medication routes, the
+  window — so the cheap option now forecloses the better option later. The
+  scope/evidence mismatch (measurement covers medication routes, the
   rule covers every read) is then closed by the widened measurement rather than
   by narrowing the rule.


### PR DESCRIPTION
Three related changes that close the loop between a spec and the work that delivers it.

## 1. Spec 049 moves to `ready`, so it fans out

OD-7 and OD-8 are still unanswered. That is no longer a reason to hold the spec, and the reasoning is worth stating because it is not obvious:

Neither question can be answered from the evidence that exists. Server telemetry measures requests that **completed**, not caregivers who **gave up** — so it is structurally incapable of telling us what an acceptable wait is. The instrument that would answer it is FR-018. FR-018 only gets built once this spec fans out.

So holding 049 in `draft` until OD-7 is settled makes OD-7 permanently unanswerable. That is exactly how spec 034 stalled — correct, never wrong, silent, and it cost the programme the same incident twice. Spec 049 documents that failure in its own text. It should not reproduce it.

## 2. OD-7/OD-8 restated as *deferred pending FR-018* rather than open

Recorded as a decision with a reason and a review point, so the deferral is visible as deliberate rather than reading as neglect.

Deferring costs nothing, because both carry provisional answers that unblock delivery:

- **30 s** stands as a safety floor — it clears the slowest legitimate read, so it will not kill healthy requests
- **Uniform** is the starting rule, since it matches the implementation already in flight, so no slice waits on this

The one consequence that genuinely cannot wait is already binding: FR-018 must record per-route-class detail **from the first day it ships**. Skip that and choosing per-class later means re-instrumenting and waiting out a second observation window — the cheap option now forecloses the better option later.

## 3. `patterns.md` §11 gains the multi-slice rule

§11 currently says a closing keyword counts as a declaration on its own. For a spec that lands as several slices, that is actively harmful:

The first slice to merge **closes the umbrella fan-out issue**. Every later slice then has nothing open to attach to, so the return path goes dark precisely when there is most left to deliver — and a half-delivered spec reads as shipped. That is one of the three failures §11 was written to prevent, reintroduced by §11's own wording.

A closing keyword is now valid **only when the PR completes the whole spec for that repo**. Slices declare `Spec: NNN` and reference the issue without closing it.

I hit this on a merged medication-regimen slice and applied the convention by hand before writing it down, which is the wrong order — the rule here is to extend `patterns.md` first, then act. This corrects that.

## What happens on merge

`spec-fanout` opens a `[spec/unicorn-diagnostics-recovery]` squad issue in **rettxweb** and **rettxadmin**. This is the first irreversible step in this sequence.

Both briefs were re-read before flipping. The rettxadmin one is deliberately outcome-level — it inherits the policy "at whatever its fatal-error surface is", and if that surface does not exist the slice is to add a minimal one, explicitly *not* to port rettxweb's recovery ladder. The two apps serve different users and make their own stack-level decisions.

## Verification

- Frontmatter validated with the fan-out workflow's own parser: parses, `status: ready`, both entries well-formed.
- No CI runs on spec PRs here, so "no checks reported" is expected.