### PR TITLE
docs(spec): 049 — correct OD-3, separate cause from producer, record the FR-012/FR-015 conflict

### DIFF
--- a/specs/049-unicorn-diagnostics-recovery/spec.md
+++ b/specs/049-unicorn-diagnostics-recovery/spec.md
@@ -331,7 +331,14 @@ event without her describing anything about her child.
   `unicorn_shown` telemetry event per visit, after render.
 - **FR-002** The event MUST carry a `cause` from a closed, enum-like set.
   `unknown` MUST be a permitted value and MUST be counted, not suppressed.
-  Producers MUST be able to hand a cause to the page.
+  Producers MUST be able to hand a cause to the page. The `cause` MUST describe
+  **what went wrong**, and MUST NOT be set to the identity of the code path that
+  emitted it; where the failure is unclassified, the cause is `unknown` even
+  though the emitting path is known. The emitting path MUST be carried as a
+  **separate dimension** so that both questions can be asked independently.
+  Recorded 2026-08-05 after two implementation attempts collapsed the two: doing
+  so drives the `unknown` rate to near zero by renaming rather than by
+  classifying, and SC-1 then reports success while measuring nothing.
 - **FR-003** The event MUST carry **build identity** — a value that distinguishes
   one deployed build from another, independent of the release version. Blank MUST
   be impossible; if identity cannot be resolved the event MUST say so explicitly.
@@ -376,6 +383,9 @@ event without her describing anything about her child.
 
 - **FR-012** All page copy MUST be translated, `en` and `es` at minimum, with the
   existing English fallback behaviour preserved. No hardcoded user-facing strings.
+  This MUST NOT be satisfied by giving the page a runtime dependency on the
+  application's translation service, which would breach FR-015. See the
+  amendment of 2026-08-05.
 - **FR-015** The page MUST be defensive: it MUST render, capture and offer
   recovery even when application services are unavailable, and MUST NOT be
   capable of throwing an error that routes back to itself.
@@ -470,7 +480,9 @@ never checked is not a criterion.
 - **SC-1 Cause coverage.** Baseline **0%** — no page-level event exists, and a
   substantial share of tracked errors carry no cause at all. Target **≥90%** of
   `unicorn_shown` events carry a cause other than `unknown`. Instrument: share of
-  `unicorn_shown` by `cause`.
+  `unicorn_shown` by `cause`. This target is only meaningful while FR-002's
+  separation holds: if the emitting path is used as the cause, the criterion
+  passes on the day it ships and measures nothing.
 - **SC-2 Build identity.** Baseline **0%** — neither build identity nor a
   staleness verdict exists. Target **100%** of `unicorn_shown` events carry both.
   Instrument: null-rate of those two dimensions.
@@ -634,6 +646,40 @@ prose and enforced by nobody. Any future spec that depends on a "measure first"
 ordering should assume the same failure until something in the pipeline makes
 the ordering visible at review time.
 
+### Amendment 2026-08-05 — FR-012 and FR-015 are in tension
+
+Surfaced during phase 1 delivery, before phase 4 starts, and recorded here so
+that phase 4 opens with the conflict already visible rather than discovering it
+mid-implementation.
+
+**The conflict.** FR-012 requires every user-facing string on the fatal page to
+be translated. FR-015 requires that page to render, capture and offer recovery
+*when application services are unavailable*. The obvious way to satisfy FR-012
+is to resolve copy through the application's runtime translation service — which
+is an application service, and therefore exactly what FR-015 forbids the page to
+depend on. Satisfying either requirement naively defeats the other.
+
+**Why this is not hypothetical.** The failure mode the page exists to survive
+includes a partially initialised application. A translation runtime that has not
+loaded, or whose locale bundle was fetched from a stale build, is a plausible
+cause of arriving at the page in the first place. Copy that resolves through it
+would render blank or as raw keys precisely when a caregiver most needs a
+sentence they can act on — and a blank fatal page is worse than an untranslated
+one.
+
+**The constraint on phase 4.** Phase 4 MUST deliver translated copy without
+introducing a runtime service dependency on the fatal surface. The mechanism is
+the delivering repository's decision, but it MUST hold two properties: copy
+resolution cannot fail in a way that leaves the page without a readable message
+and a usable recovery action, and an unresolvable locale MUST fall back to
+English rather than to a key or to nothing. If those cannot both be met, FR-015
+wins and FR-012 is deferred with that fact recorded — an untranslated page that
+works outranks a translated page that might not render.
+
+**Standing note for reviewers.** Until phase 4 lands, hardcoded English on this
+page is expected, not an oversight, and a review that flags it as a defect is
+reading the wrong phase. The strings predate this spec.
+
 ## Risks
 
 - **R1 — Recovery loop.** A recovery that re-triggers the failure could loop on a
@@ -743,12 +789,29 @@ raised as OD-6.
   compare against, the verdict MUST be `unavailable` — never `fresh`, which
   would be a lie, and never blank.
 - **OD-3** ~~What is the initial cause taxonomy?~~ **Resolved 2026-08-04 —
-  `stale-build`, `auth`, `data-load`, `network`, `unknown`.** Grounded in the
-  producers that route to the page today rather than in anticipated ones. None
-  of them passes a cause at present, which is precisely why FR-014 requires that
-  an untagged producer surface as `unknown` rather than as silence. `auth`
+  `stale-build`, `auth`, `data-load`, `network`, `unknown`.** None of the
+  producers passes a cause at present, which is precisely why FR-014 requires
+  that an untagged producer surface as `unknown` rather than as silence. `auth`
   stays a single bucket until the classifier work lands; splitting it now would
   invent distinctions the data cannot support.
+
+  **Justification corrected 2026-08-05. The values stand; the reasoning given
+  for them did not.** The original wording claimed the set was "grounded in the
+  producers that route to the page today rather than in anticipated ones". That
+  is false for two of the five. Phase 1 delivery established that exactly two
+  producers route to the fatal page, yielding `stale-build`, `data-load` and
+  `unknown`. `auth` is not among them — authentication failures are deliberately
+  routed away from this page — and nothing produces `network` at all. Both
+  describe anticipated producers, which is the thing that sentence disclaimed.
+
+  **The values do not change**, for two reasons. A bucket that reads zero is
+  itself a finding, whereas a value never defined records nothing. And trimming
+  the set to today's producers would make the taxonomy a moving target across
+  the observation window, defeating the comparison the window exists for. What
+  changes is the claim: the set is grounded in the failure modes this programme
+  expects to distinguish, two of which are not yet reachable. Any review of the
+  cause distribution MUST read `auth` and `network` as structurally zero, not as
+  evidence that those failures do not occur.
 - **OD-4** ~~Should the incident code be the correlation id, a truncation of it,
   or a separate value?~~ **Resolved 2026-08-04 — a separate per-incident value,
   emitted alongside the existing correlation id.** That id is scoped to the


### PR DESCRIPTION
Three corrections to spec 049, all surfaced by phase 1 delivery. None of them changes what the spec requires to be built; all three change what it *claims*, or make explicit something it left implicit and an implementer then got wrong.

## 1. OD-3's justification was inaccurate

OD-3 resolved the cause taxonomy to five values and justified them as "grounded in the producers that route to the page today rather than in anticipated ones". Phase 1 delivery established that this is **false for two of the five**: authentication failures are deliberately routed away from the fatal page, and nothing produces the network cause at all. Both describe anticipated producers — the thing that sentence explicitly disclaimed.

**The values are unchanged.** A bucket that reads zero is itself a finding, whereas a value never defined records nothing; and trimming the set to today's producers would make the taxonomy a moving target across the observation window, defeating the comparison the window exists for. What changes is the claim, plus an instruction to reviewers to read those two buckets as *structurally zero* rather than as evidence those failures do not occur.

## 2. `cause` and the emitting path are now explicitly separate (FR-002, SC-1)

The spec used "producer" throughout as a concept but never said the event carries it as a dimension, and never said a cause may not simply *be* a producer identity. **Two independent implementation attempts collapsed the two** — labelling unclassified errors with the name of the handler that caught them.

That is not a cosmetic error. It drives the `unknown` rate to near zero by renaming rather than by classifying, so **SC-1 passes at ~100% on the day it ships while measuring nothing** — the same class of false-green this spec exists to eliminate. FR-002 now requires the cause to describe what went wrong, requires `unknown` where the failure is unclassified even though the emitting path is known, and requires the emitting path as a separate dimension. SC-1 carries the matching caveat.

## 3. FR-012 and FR-015 are in tension — recorded before phase 4 starts

FR-012 requires all page copy translated. FR-015 requires the page to render, capture and offer recovery *when application services are unavailable*. The obvious way to satisfy FR-012 is to resolve copy through the application's runtime translation service — which is an application service, and so exactly what FR-015 forbids the page to depend on.

Not hypothetical: a translation runtime that never loaded, or whose locale bundle came from a stale build, is a plausible reason for arriving at the fatal page at all. Copy resolved through it would render blank or as raw keys precisely when a caregiver most needs a sentence they can act on.

The amendment constrains phase 4 to translate without a runtime service dependency, requires an unresolvable locale to fall back to English rather than to a key or to nothing, and states that **if both cannot hold, FR-015 wins** — an untranslated page that works outranks a translated page that might not render. It also adds a standing note that hardcoded English on this page is expected until phase 4, so reviewers stop filing it as a defect.

## Notes

- `status` stays `ready`; fan-out is idempotent and this opens no new squad issues.
- Frontmatter validated: parses, both fan-out entries well-formed.
- No mechanisms, file paths, symbol names, private issue references or production measurements were introduced — checked line by line against the public/private boundary.