### PR TITLE
docs(spec): mark 034 superseded and drop its backend half explicitly

### DIFF
--- a/specs/034-auth-observability/spec.md
+++ b/specs/034-auth-observability/spec.md
@@ -20,7 +20,7 @@
 spec_id: "034"
 slug: "auth-observability"
 title: "rettX Auth-Failure Observability & Diagnosability"
-status: draft   # draft | ready | accepted | superseded
+status: superseded   # draft | ready | accepted | superseded
 authored: "2026-07-13"
 author: "perocha"
 source_issue: "rett-europe/rettx#31"
@@ -127,7 +127,27 @@ fanout:
 
 # Feature Specification: rettX Auth-Failure Observability & Diagnosability
 
-**Spec ID**: `034-auth-observability` · **Status**: Draft · **Created**: 2026-07-13
+**Spec ID**: `034-auth-observability` · **Status**: Superseded · **Created**: 2026-07-13
+
+> **Superseded on 2026-08-05.** This spec never left `draft`, and it is now closed
+> without being delivered as written. Everything below is retained as a record of
+> what was asked for and why; none of it is an outstanding commitment.
+>
+> Its client-side requirements were either delivered through incident-driven work
+> or carried into [spec 049](../049-unicorn-diagnostics-recovery/spec.md), which
+> audits them one by one against the code. Two were carried forward explicitly:
+> FR-012's principle as 049's D7, and FR-013's alert as 049's FR-017.
+>
+> Its backend half was **not** carried forward and is **not** being re-specified.
+> That is a deliberate decision, not an oversight: this spec is over three weeks
+> old, it stalled on unanswered questions rather than on disagreement, and the
+> programme is choosing to move on rather than keep a stale draft alive. If the
+> behaviour it describes is still wrong, it will surface as a bug and be handled
+> on its own merits.
+>
+> The governance lesson is recorded in 049 (OD-6) and in `patterns.md`: a correct
+> spec that nobody rejects can still die of silence, and nothing in the pipeline
+> makes that visible.
 **Source issue**: [rett-europe/rettx#31](https://github.com/rett-europe/rettx/issues/31) (cross-cutting)
 **Owner**: rettX control plane (this repo) — authored and coordinated here; scoped work is fanned out to the affected repos via the `spec-fanout` workflow on merge.
 **Input**: A pilot user's native app hangs on cold start; the only signal is a burst of context-free `403 {'detail': 'Not authenticated'}` server exceptions on `GET /v2/patients`. Diagnosing it required hours of code archaeology. "How will we detect when something is going south, when all we see is a cryptic burst of 403?"

--- a/specs/049-unicorn-diagnostics-recovery/spec.md
+++ b/specs/049-unicorn-diagnostics-recovery/spec.md
@@ -733,10 +733,11 @@ No principle is weakened; no amendment is required.
 
 ## Relationship to spec 034
 
-Spec 034 (*auth-failure observability & diagnosability*, authored 2026-07-13) has
-sat at `status: draft` ever since, so it never fanned out. Much of it was
-nonetheless delivered through incident-driven work. The client-side position was
-**verified against the code on 2026-08-04**, not assumed:
+Spec 034 (*auth-failure observability & diagnosability*, authored 2026-07-13) sat
+at `status: draft` and never fanned out. It was **superseded on 2026-08-05**
+without being delivered as written. Much of it was nonetheless delivered through
+incident-driven work. The client-side position was **verified against the code on
+2026-08-04**, not assumed:
 
 | 034 requirement | state today |
 |---|---|
@@ -748,9 +749,18 @@ nonetheless delivered through incident-driven work. The client-side position was
 | FR-013 proactive rate alert | **not delivered** |
 
 Two things are therefore carried into this spec rather than left in a stalled
-draft: **FR-012's principle**, as D7, and **FR-013's alert**, as FR-017. The
-backend half of 034 (FR-001–FR-006, rettxapi auth-failure shaping) is untouched
-by this spec and remains 034's to resolve.
+draft: **FR-012's principle**, as D7, and **FR-013's alert**, as FR-017.
+
+The backend half of 034 (FR-001–FR-006, rettxapi auth-failure shaping) is
+untouched by this spec and was **not** inherited by it. When 034 was superseded on
+2026-08-05 that half was deliberately dropped rather than re-specified — the draft
+was over three weeks old and the programme chose to move on rather than keep it
+alive. It is nobody's outstanding commitment. If the behaviour is still wrong it
+will surface as a bug and be handled on its own merits.
+
+Reviewers should read one consequence of that into OD-3: the `auth` cause has no
+producer today and none is scheduled, so it stays structurally zero for the same
+reason `network` does. A zero there is not evidence that auth failures are rare.
 
 The governance lesson is worth stating plainly, because it cost the programme the
 same incident twice: 034 was correct, was never wrong, and stalled anyway — on


### PR DESCRIPTION
Closes spec 034 (*auth-failure observability & diagnosability*) as **superseded**, and fixes the pointer in spec 049 that would otherwise dangle.

## Why

034 was authored 2026-07-13, never left `draft`, and therefore never fanned out. It was not rejected and was never shown to be wrong — it stalled on four unanswered questions. It is now over three weeks old and the programme is choosing to move on rather than keep a stale draft alive.

## What changes

**`specs/034-auth-observability/spec.md`**
- `status: draft` → `status: superseded`, and the header status line matched to it
- A dated note at the top explaining what was carried forward, what was dropped, and that nothing below is an outstanding commitment. The body is retained as a record of what was asked for and why.

**`specs/049-unicorn-diagnostics-recovery/spec.md`**
- The "Relationship to spec 034" section said the backend half *"remains 034's to resolve"*. With 034 superseded that sentence pointed at a closed spec — work that looks accounted for while belonging to nobody. Both documents now say the same thing: that half was **deliberately dropped**, is **not** being re-specified, and if the behaviour is still wrong it surfaces as a bug and is handled on its own merits.
- Records the consequence for OD-3, so a reader does not misread a metric: the `auth` cause has no producer today and none is scheduled, so it stays **structurally zero** for the same reason `network` does. A zero there is not evidence that auth failures are rare.

## What was carried forward

049 audited 034's client-side requirements against the code on 2026-08-04 rather than assuming. Two were carried forward explicitly — FR-012's principle as 049's **D7**, FR-013's alert as 049's **FR-017**. That table stays as it was; this PR does not restate it.

## Fan-out

None. `status: superseded` is not `ready` or `accepted`, so this opens no squad issues. 049 remains `ready`; fan-out is idempotent and skips targets that already have a `[spec/…]` issue, so re-running it on merge opens no duplicates.

## Governance note

This is the second time the same lesson has been recorded: a correct spec that nobody rejects can still die of silence, and nothing in the pipeline makes a quiet draft visible. That gap is not fixed here — it is raised as 049's OD-6 and noted in `patterns.md`.

Spec: none — closes a superseded spec and repairs a cross-reference; no downstream delivery.