### PR TITLE
docs(spec): 050 — FR-001a names which inputs may settle the row set

### DIFF
--- a/specs/050-treatment-timeline-render/spec.md
+++ b/specs/050-treatment-timeline-render/spec.md
@@ -315,6 +315,24 @@ number of medications.
   that rearranges itself, and it fails safe toward showing the caregiver more
   rather than less.
 
+  FR-001a also governs *which inputs* may inform that decision, which is a
+  separate question from when it is taken. The row set MUST be settled from the
+  data that establishes the rows themselves. A chart may draw additional
+  material onto a row from a source loaded separately — markers for what a
+  caregiver reported against a course, for instance — and such a source can in
+  principle argue for keeping a row that the primary data alone would exclude.
+  That argument MAY be honoured only where the secondary source is already in
+  hand when the view is established. It MUST NOT delay the first paint, and it
+  MUST NOT reopen the decision once taken. The consequence is deliberate and
+  accepted: a row that a late-arriving secondary source would have justified is
+  absent until the caregiver next establishes a view. Both alternatives are
+  worse — one makes every caregiver wait on data almost none of them need, and
+  the other makes a row appear after the chart has been read, which is the
+  defect this spec exists to remove. Implementations MUST NOT record the
+  keep-rule as though it applied on first load when it cannot; a comment or
+  contract that promises more than the code delivers will be closed by a future
+  reader in exactly the way this requirement forbids.
+
 - **FR-002** Row order MUST be the order supplied by the backend, established
   once, before any per-row data resolves. The client MUST NOT re-sort the chart.
 

--- a/specs/050-treatment-timeline-render/spec.md
+++ b/specs/050-treatment-timeline-render/spec.md
@@ -333,6 +333,26 @@ number of medications.
   contract that promises more than the code delivers will be closed by a future
   reader in exactly the way this requirement forbids.
 
+  The residual case this leaves is known, and is named here so that nobody
+  mistakes it for a defect or "fixes" it by weakening FR-001. Absence can be
+  proven up front only for a course that had already finished before the window
+  opened. A course that stopped and later restarted cannot be ruled out that
+  way: viewed in the interval between the two, it is still an active course, and
+  only its full history shows that it covered no part of the window. Such a row
+  MUST therefore be kept and will render as an unoccupied row for that view.
+  This is a first-paint artefact, not a permanent one — when the caregiver next
+  establishes a view the full history is in hand, the case becomes decidable,
+  and the row correctly disappears. It requires a stop, a restart, and a view
+  landing in the gap between them, so it is rare; and it is strictly preferable
+  to the alternative, which is a row vanishing from a chart the caregiver has
+  already started reading.
+
+  This class of problem is an artefact of history arriving after the rows do. It
+  disappears entirely once the chart obtains every version in the same response
+  that establishes the rows (FR-007, FR-011), at which point every inclusion
+  case is decidable before first paint. The keep-rule above is what correctness
+  requires in the interim, not a permanent accommodation.
+
 - **FR-002** Row order MUST be the order supplied by the backend, established
   once, before any per-row data resolves. The client MUST NOT re-sort the chart.
 


### PR DESCRIPTION
FR-001a settled *when* the row set is decided. It never said *from what*.

That gap is not theoretical. A chart draws some material onto a row from a
source loaded separately from the one that establishes the rows, and that
source can legitimately argue for keeping a row the primary data alone would
exclude — remove the row and you remove the marker with it. Read against
FR-001a as merged, an implementer could take that as licence to revise the row
set when the secondary source lands. That is precisely the defect spec 050
exists to remove, arrived at by following the spec rather than by ignoring it.

This makes the rule explicit:

- settle the row set from the data that establishes the rows;
- honour a secondary source only where it is already in hand when the view is
  established;
- never delay first paint for it, and never reopen the decision afterwards.

The residue is named rather than left to be discovered: a row that a
late-arriving source would have justified stays absent until the caregiver next
establishes a view. Both alternatives are worse — one makes every caregiver
wait on data almost none of them need, the other makes a row appear after the
chart has been read.

It also adds an obligation that came out of reviewing the delivered client
work: do not document the keep-rule as though it applied on first load where it
cannot. An accurate-sounding comment describing a guarantee the primary path
does not deliver is what invites someone to "close the gap" by delaying the
decision — the forbidden change, made in good faith.

Raised by the implementing session, which resolved it correctly and asked for
the wording rather than leaving the next reader to re-derive it.

Spec: 050
Part of #307 — does not close it.
