### PR TITLE
docs: require a total order where the client is forbidden to re-sort

### DIFF
--- a/specs/046-medication-regimen/contracts/medication-regimen-api.md
+++ b/specs/046-medication-regimen/contracts/medication-regimen-api.md
@@ -165,6 +165,22 @@ Returns, per `medication_id`, the latest `version` whose
   so an ordering that is not total surfaces as a chart that rearranges itself
   between refreshes. This applies to every response that carries medications in
   a list, including the batched version chains below.
+
+  `name` ascending is compared **case-folded, by code point** — not by locale
+  collation. This is deliberate and MUST NOT be "improved" to a locale-aware
+  comparison: the response is shared and cacheable, so a locale-sensitive order
+  would let the same data come back in different orders for different callers,
+  which is unorderable in a client that is required not to re-sort. Any client
+  fixture or mock MUST fold the same way; one that compares with a locale-aware
+  collation renders a plausible chart whose row positions differ from
+  production, and nothing fails.
+
+  Known consequence, recorded rather than hidden: code-point comparison places
+  every accented name after every unaccented one, so a name beginning `É` sorts
+  past `Z`. For a European register of drug names that is visibly odd. Whether
+  the sort key should additionally fold diacritics — which would keep the order
+  locale-independent and deterministic while placing `É` beside `E` — is an
+  open decision (spec 050, OD-4), not a licence to switch to collation.
 - A patient with no medications returns `"medications": []` and HTTP 200 — never
   404.
 - `latest_weight` / `latest_height` are `null` when no such entry exists. The

--- a/specs/046-medication-regimen/contracts/medication-regimen-api.md
+++ b/specs/046-medication-regimen/contracts/medication-regimen-api.md
@@ -182,10 +182,17 @@ Returns, per `medication_id`, the latest `version` whose
   This is deliberate and MUST NOT be "improved" to a locale-aware
   comparison: the response is shared and cacheable, so a locale-sensitive order
   would let the same data come back in different orders for different callers,
-  which is unorderable in a client that is required not to re-sort. Any client
-  fixture or mock MUST fold the same way; one that compares with a locale-aware
-  collation renders a plausible chart whose row positions differ from
-  production, and nothing fails.
+  which is unorderable in a client that is required not to re-sort.
+
+  Anything standing in for the server in a test — a mock, a fixture, a stub —
+  MUST NOT produce an order the server would not produce. How it achieves that
+  is the client's decision, and the obligation is not "reimplement the fold": a
+  stand-in that can only guarantee agreement over part of the input range
+  satisfies this by **failing loudly** on anything outside that range, rather
+  than ordering it plausibly. What is forbidden is the silent case, where the
+  stand-in orders unfamiliar input by some rule of its own, every test passes,
+  and the chart it renders disagrees with the one caregivers see. A stand-in
+  that stops is a failed test; a stand-in that guesses is a false one.
 
   Known consequence, recorded rather than hidden: code-point comparison places
   every accented name after every unaccented one, so a name beginning `É` sorts

--- a/specs/046-medication-regimen/contracts/medication-regimen-api.md
+++ b/specs/046-medication-regimen/contracts/medication-regimen-api.md
@@ -156,7 +156,15 @@ Returns, per `medication_id`, the latest `version` whose
 }
 ```
 
-- Ordering: `name` ascending, `as_needed` rows last (they print as a block).
+- Ordering: `name` ascending, `as_needed` rows last (they print as a block), and
+  ties broken by `medication_id` so the order is total. The tie-break is not
+  cosmetic: two prescriptions of the same drug at different doses share both
+  `name` and `as_needed`, and without a unique final key their relative order
+  falls through to storage order and may differ between reads. Clients are
+  required to render server order without re-sorting (spec 050, FR-002/FR-002a),
+  so an ordering that is not total surfaces as a chart that rearranges itself
+  between refreshes. This applies to every response that carries medications in
+  a list, including the batched version chains below.
 - A patient with no medications returns `"medications": []` and HTTP 200 — never
   404.
 - `latest_weight` / `latest_height` are `null` when no such entry exists. The

--- a/specs/046-medication-regimen/contracts/medication-regimen-api.md
+++ b/specs/046-medication-regimen/contracts/medication-regimen-api.md
@@ -167,7 +167,19 @@ Returns, per `medication_id`, the latest `version` whose
   a list, including the batched version chains below.
 
   `name` ascending is compared **case-folded, by code point** — not by locale
-  collation. This is deliberate and MUST NOT be "improved" to a locale-aware
+  collation. "Case-folded" here means **full Unicode case folding** (the full
+  form defined by Unicode's `CaseFolding` data), not lowercasing. The two are
+  not interchangeable and the difference is reachable in drug names: full
+  folding maps `ß` to `ss`, the micro sign `µ` to Greek mu `μ`, the `ﬁ` ligature
+  to `fi`, and Greek final sigma `ς` to `σ`; lowercasing maps none of them. `µg`
+  is an ordinary dose unit, and a keyboard emits the micro sign where a document
+  may carry Greek mu, so two names differing only in which character they use
+  fold together on the server and stay apart under a naive lowercase.
+  Implementations MUST name and use the standard rather than accumulate
+  character replacements: a hand-maintained substitution list matches until it
+  meets the next character nobody thought of, and produces no error when it
+  fails.
+  This is deliberate and MUST NOT be "improved" to a locale-aware
   comparison: the response is shared and cacheable, so a locale-sensitive order
   would let the same data come back in different orders for different callers,
   which is unorderable in a client that is required not to re-sort. Any client

--- a/specs/046-medication-regimen/contracts/medication-regimen-api.md
+++ b/specs/046-medication-regimen/contracts/medication-regimen-api.md
@@ -194,6 +194,14 @@ Returns, per `medication_id`, the latest `version` whose
   and the chart it renders disagrees with the one caregivers see. A stand-in
   that stops is a failed test; a stand-in that guesses is a false one.
 
+  The obligation follows the stand-in, not the test. Where the same stand-in
+  also backs a runnable surface — a development or demonstration mode — it holds
+  there too, and "loudly" then has a second half: the failure MUST reach someone
+  who can act on it, and MUST NOT be shown to a person using the surface as
+  though it were data. Which layer refuses is the client's choice; refusing
+  where the row set is assembled generally satisfies both halves, refusing
+  during render generally satisfies neither.
+
   Known consequence, recorded rather than hidden: code-point comparison places
   every accented name after every unaccented one, so a name beginning `É` sorts
   past `Z`. For a European register of drug names that is visibly odd. Whether

--- a/specs/050-treatment-timeline-render/spec.md
+++ b/specs/050-treatment-timeline-render/spec.md
@@ -539,3 +539,9 @@ number of medications.
   fixed silently. What is NOT open: switching to a locale-aware collation to
   achieve the same effect, which FR-002a forbids for reasons that have nothing
   to do with how the result looks.
+
+  If OD-4 is ever taken, the server's rule and every fixture standing in for it
+  MUST change in the same step. Moving either alone recreates precisely the
+  divergence that made this requirement necessary, and recreates it silently —
+  the fixture keeps passing, and the chart it renders stops matching the one
+  caregivers see.

--- a/specs/050-treatment-timeline-render/spec.md
+++ b/specs/050-treatment-timeline-render/spec.md
@@ -331,6 +331,16 @@ number of medications.
   not a contrived one: the same medication is legitimately recorded twice at
   different doses, and every human-meaningful sort key it has is shared.
 
+  Stability also means stable *across callers*, not only across reads. An
+  ordering that depends on the caller's locale is not stable in this sense: the
+  same shared, cacheable response can then be legitimately ordered two ways,
+  and a client forbidden to re-sort has no way to reconcile them or even to
+  detect the difference. Comparison rules MUST therefore be fixed by the
+  contract and locale-independent, and any client fixture standing in for the
+  server MUST reproduce them — a fixture that orders differently produces a
+  plausible chart whose row positions silently differ from production, and no
+  test fails.
+
 - **FR-003** The ordering guarantee in FR-001 MUST hold regardless of the order,
   timing or interleaving in which underlying responses arrive, and MUST hold
   when two rows carry the same displayed medication name with different
@@ -513,3 +523,19 @@ number of medications.
 
   If it is later bounded, FR-011a governs how: selection MUST be by overlap with
   the window, never by when a version was created or took effect.
+
+- **OD-4 — Should the name sort key fold diacritics?** The order is compared
+  case-folded by code point, which is deterministic and locale-independent and
+  must stay that way (FR-002a). The side effect is that every accented name
+  sorts after every unaccented one, so a drug beginning `É` lands past `Z`. On a
+  European register of drug names that is visibly wrong to a caregiver, who sees
+  an alphabetical list with a handful of drugs stranded at the end.
+
+  Folding diacritics into the sort key would place `É` beside `E` while keeping
+  the order deterministic and locale-independent, so it does not reopen the
+  question FR-002a settles. It is recorded as an open decision rather than a
+  requirement because it changes the order of existing responses, which is a
+  product judgement about what caregivers should see and not a defect to be
+  fixed silently. What is NOT open: switching to a locale-aware collation to
+  achieve the same effect, which FR-002a forbids for reasons that have nothing
+  to do with how the result looks.

--- a/specs/050-treatment-timeline-render/spec.md
+++ b/specs/050-treatment-timeline-render/spec.md
@@ -318,6 +318,19 @@ number of medications.
 - **FR-002** Row order MUST be the order supplied by the backend, established
   once, before any per-row data resolves. The client MUST NOT re-sort the chart.
 
+- **FR-002a** FR-002 places the whole ordering guarantee on the backend, so the
+  order the backend supplies MUST be total: for a given set of records it MUST
+  be identical on every read. An ordering rule whose keys two records can share
+  does not meet this, however sensible it looks — the records that tie then fall
+  back to whatever order storage happened to return, which may differ between
+  two reads of unchanged data. The visible result is a chart that reorders
+  itself between refreshes, which is the defect this spec exists to remove,
+  reached by a different route and not fixable by any client that honours
+  FR-002. Ordering rules MUST therefore end in a key that is unique per record.
+  Two prescriptions of the same drug are the ordinary case that exposes this,
+  not a contrived one: the same medication is legitimately recorded twice at
+  different doses, and every human-meaningful sort key it has is shared.
+
 - **FR-003** The ordering guarantee in FR-001 MUST hold regardless of the order,
   timing or interleaving in which underlying responses arrive, and MUST hold
   when two rows carry the same displayed medication name with different


### PR DESCRIPTION
Two documents, each defensible on its own, jointly permitting the defect this
spec exists to remove.

Spec 050 FR-002 places the entire ordering guarantee on the backend: the client
renders the order it is given and MUST NOT re-sort. The 046 contract then
specified that order as `name` ascending with `as_needed` last — a rule whose
keys two records can share.

Two prescriptions of the same drug at different doses tie on both keys. Their
relative order therefore fell through to whatever storage returned, which is not
guaranteed stable between reads. The visible consequence is a chart whose rows
can swap places between refreshes, in front of a caregiver, with no client-side
remedy available to anyone honouring FR-002.

This is the same user-visible symptom as the original defect, reached by an
entirely different route, and it was latent in the same patient data — the case
that first exposed this whole spec was a drug recorded twice.

- **FR-002a** requires the supplied order to be total: identical on every read
  for a given set of records, with a final key unique per record.
- The **046 contract** ordering rule gains that final key, and states why it is
  not cosmetic, so the next person to write an ordering rule for these
  endpoints sees the requirement rather than inferring the pattern.

The same-drug-twice case is named as ordinary rather than contrived. It is
clinically normal, it is what breaks name-keyed shapes, and it is what exposed
both defects in this spec — it should stop being a surprise.

Found by the implementing session reading the contract against its own builders,
which is the review the contract had not previously had.

Spec: 050
Part of #370 — does not close it.
