### PR TITLE
docs(spec): 051 ready — fan out error-screen parity to rettxweb

### DIFF
--- a/specs/051-error-screen-parity/spec.md
+++ b/specs/051-error-screen-parity/spec.md
@@ -22,7 +22,7 @@
 spec_id: "051"
 slug: "error-screen-parity"
 title: "No error screen may trap a caregiver, and none may go unseen"
-status: draft   # draft | ready | accepted | superseded
+status: ready   # draft | ready | accepted | superseded
 authored: "2026-08-06"
 author: "perocha"
 relates_to: "specs/049-unicorn-diagnostics-recovery/ (established the treatment this spec generalises, and left the gaps this spec closes); specs/034-auth-observability/ (per-install correlation id)"


### PR DESCRIPTION
Flips spec **051 · error-screen-parity** from `draft` to `ready` so the `spec-fanout` workflow opens the rettxweb squad issue **on merge**.

**What this does**
- One-line frontmatter change: `status: draft` → `status: ready`. Spec content is unchanged.
- On merge, fan-out routes **only to rettxweb** (client-behaviour only; no rettxapi/schema/templates slice, per the spec's pre-flight — it reuses spec 049's diagnostic payload).

**Why now**
- The spec was merged as draft (#79) and reviewed in the open. Its requirements are concrete and already cover the error-screen behaviour observed post-deploy of spec 050: capture the machine-readable reason instead of reporting `unknown` (FR-004), no dead-end recovery / start-link-not-the-only-action (FR-005/006), and copy that doesn't lead with a protocol status code (FR-009).

**Notes for reviewers**
- No CI runs on spec PRs (only `iris-route`/`spec-fanout` trigger, neither validates content) — "no checks reported" is expected, not a failure.
- The `OD-1..3` open decisions are deliberate product questions and do not block fan-out; they mirror how spec 050 shipped with open ODs.
- Fan-out happens on **merge**, not on opening this PR.

Part of the spec-050/049 error-handling line; does not close any issue.