### PR TITLE
docs(spec): 051 — record the additive payload amendment (screen + arrival_reason)

### DIFF
--- a/specs/051-error-screen-parity/spec.md
+++ b/specs/051-error-screen-parity/spec.md
@@ -342,9 +342,12 @@ rather than reported as an improvement from zero.
 - The five screens named here are the complete set of caregiver-facing error
   surfaces in the caregiver application as of 2026-08-06. Any surface added
   later inherits these requirements.
-- The diagnostic payload established by 049 is adequate for these screens and
-  does not need extending. If it does, that is an amendment here, not a parallel
-  payload.
+- The diagnostic payload established by 049 is the basis for these screens.
+  FR-002 and FR-004 require two additive fields it does not yet carry —
+  `screen` (which surface appeared) and `arrival_reason` (the machine-readable
+  cause, where a producer states one). Adding these is the additive amendment
+  this section anticipated: it stays one shared 049-derived payload, not a
+  parallel one.
 
 ## Out of scope
 


### PR DESCRIPTION
## What

Realises the payload amendment that spec 051's §Assumptions anticipated.

The section previously read: *"The diagnostic payload established by 049 is adequate for these screens and does not need extending. If it does, that is an amendment here, not a parallel payload."*

FR-002 requires the record to identify **which** screen appeared, and FR-004 requires the machine-readable arrival reason to be captured. Neither field exists on 049's payload. So this records the anticipated amendment: `screen` and `arrival_reason` are added **additively** to the one shared 049-derived payload — not a parallel payload.

## Why now

Both rettxweb Phase 1 (observe) and Phase 3 (quality) working sessions on `#315` are underway. Phase 1's plan surfaced that FR-002/FR-004 cannot be met without these two fields, and correctly flagged it as the amendment case the Assumption anticipated rather than silently forking. This keeps the merged spec internally consistent with what Phase 1 implements.

## Scope

- One paragraph in `specs/051-error-screen-parity/spec.md` §Assumptions.
- **No** requirement, success criterion, open decision, or `fanout:` entry changes.
- Status stays `ready`. Re-merging is safe: `spec-fanout.yml` is idempotent (existing `[spec/051-error-screen-parity]` issue on rettxweb → target skipped, no duplicate).

Spec: 051